### PR TITLE
Add exceptions to plugins; fix unit tests where necessary

### DIFF
--- a/fact_extractor/plugins/unpacking/ambarella/code/ambarella.py
+++ b/fact_extractor/plugins/unpacking/ambarella/code/ambarella.py
@@ -4,7 +4,7 @@ import re
 from os import chdir, getcwd, path, remove, rename
 
 from common_helper_files import get_files_in_dir
-from common_helper_process import execute_shell_command
+from common_helper_process import execute_shell_command_get_return_code
 from helperFunctions.file_system import get_src_dir
 
 NAME = 'Ambarella'
@@ -20,14 +20,18 @@ def unpack_function(file_path, tmp_dir):
     fallback_directory = getcwd()
     chdir(tmp_dir)
 
-    output = execute_shell_command('fakeroot {} -x -vv -m {}'.format(script_path, file_path)) + "\n"
+    output, return_code = execute_shell_command_get_return_code('fakeroot {} -x -vv -m {}'.format(script_path, file_path)) + "\n"
+
 
     _rename_files(file_path)
     _remove_ini_files()
 
     chdir(fallback_directory)
 
-    meta_data = {'output': output}
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+
+    meta_data = {'output': output, 'return_code': return_code}
     logging.debug(output)
     return meta_data
 

--- a/fact_extractor/plugins/unpacking/ambarella/code/ambarella_romfs.py
+++ b/fact_extractor/plugins/unpacking/ambarella/code/ambarella_romfs.py
@@ -1,7 +1,8 @@
 
+import logging
 from os import path
 
-from common_helper_process import execute_shell_command
+from common_helper_process import execute_shell_command_get_return_code
 from helperFunctions.file_system import get_fact_bin_dir
 
 NAME = 'Ambarella_RomFS'
@@ -15,8 +16,14 @@ def unpack_function(file_path, tmp_dir):
     if not path.exists(TOOL_PATH):
         return {'output': "Error: phantom_firmware_tools not installed! Re-Run the installation script!"}
 
-    output = execute_shell_command('(cd {} && fakeroot {} -x -vv -p {})'.format(tmp_dir, TOOL_PATH, file_path)) + "\n"
-    meta_data = {'output': output}
+    output, return_code = execute_shell_command_get_return_code('(cd {} && fakeroot {} -x -vv -p {})'.format(tmp_dir, TOOL_PATH, file_path))
+
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+
+    meta_data = {'output': output, 'return_code': return_code}
+    logging.debug(output)
+    
     return meta_data
 
 

--- a/fact_extractor/plugins/unpacking/avm_sqfs_fake/code/avm_sqfs_fake.py
+++ b/fact_extractor/plugins/unpacking/avm_sqfs_fake/code/avm_sqfs_fake.py
@@ -1,7 +1,9 @@
 '''
 This plugin unpacks avm file system container
 '''
-from common_helper_process import execute_shell_command
+import logging
+
+from common_helper_process import execute_shell_command_get_return_code
 
 NAME = 'avm_sqfs_fake'
 MIME_PATTERNS = ['filesystem/avm-sqfs-fake']
@@ -9,9 +11,12 @@ VERSION = '0.1'
 
 
 def unpack_function(file_path, tmp_dir):
-    output = execute_shell_command('dd if={} of={}/image.ext2 bs=256 skip=1 conv=sync'.format(file_path, tmp_dir))
-    return {'output': output}
-
+    output, return_code = execute_shell_command_get_return_code('dd if={} of={}/image.ext2 bs=256 skip=1 conv=sync'.format(file_path, tmp_dir))
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
+    logging.debug(output)
+    return meta_data
 
 # ----> Do not edit below this line <----
 def setup(unpack_tool):

--- a/fact_extractor/plugins/unpacking/deb/code/deb.py
+++ b/fact_extractor/plugins/unpacking/deb/code/deb.py
@@ -1,7 +1,9 @@
 '''
 This plugin unpacks debian packages
 '''
-from common_helper_process import execute_shell_command
+import logging
+
+from common_helper_process import execute_shell_command_get_return_code
 
 NAME = 'Deb'
 MIME_PATTERNS = ['application/vnd.debian.binary-package']
@@ -9,8 +11,12 @@ VERSION = '0.1'
 
 
 def unpack_function(file_path, tmp_dir):
-    return {'output': execute_shell_command('fakeroot dpkg-deb -v -x {} {}'.format(file_path, tmp_dir))}
-
+    output, return_code = execute_shell_command_get_return_code('fakeroot dpkg-deb -v -x {} {}'.format(file_path, tmp_dir))
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code }
+    logging.debug(output)
+    return meta_data
 
 # ----> Do not edit below this line <----
 def setup(unpack_tool):

--- a/fact_extractor/plugins/unpacking/dji/code/dji_drones.py
+++ b/fact_extractor/plugins/unpacking/dji/code/dji_drones.py
@@ -1,9 +1,10 @@
 
+import logging
 import re
 from os import path, rename
 
 from common_helper_files import delete_file, get_files_in_dir
-from common_helper_process import execute_shell_command
+from common_helper_process import execute_shell_command_get_return_code
 from helperFunctions.file_system import get_fact_bin_dir
 
 NAME = 'DJI_drones'
@@ -17,11 +18,15 @@ def unpack_function(file_path, tmp_dir):
     if not path.exists(TOOL_PATH):
         return {'output': 'Error: phantom_firmware_tools not installed! Re-Run the installation script!'}
 
-    output = execute_shell_command('(cd {} && fakeroot python3 {} -x -vv -p {})'.format(tmp_dir, TOOL_PATH, file_path)) + '\n'
+    output, return_code = execute_shell_command_get_return_code('(cd {} && fakeroot python3 {} -x -vv -p {})'.format(tmp_dir, TOOL_PATH, file_path))
 
     _rename_files(tmp_dir)
     _remove_ini_files(tmp_dir)
-    meta_data = {'output': output}
+
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
+    logging.debug(output)
     return meta_data
 
 

--- a/fact_extractor/plugins/unpacking/generic_carver/code/generic_carver.py
+++ b/fact_extractor/plugins/unpacking/generic_carver/code/generic_carver.py
@@ -3,7 +3,7 @@ This plugin unpacks all files via carving
 '''
 import logging
 
-from common_helper_process import execute_shell_command
+from common_helper_process import execute_shell_command_get_return_code
 
 NAME = 'generic_carver'
 MIME_PATTERNS = ['generic/carver']
@@ -17,8 +17,12 @@ def unpack_function(file_path, tmp_dir):
     '''
 
     logging.debug('File Type unknown: execute binwalk on {}'.format(file_path))
-    output = execute_shell_command('binwalk --extract --carve --signature --directory  {} {}'.format(tmp_dir, file_path))
-    return {'output': output}
+    output, return_code = execute_shell_command_get_return_code('binwalk --extract --carve --signature --directory  {} {}'.format(tmp_dir, file_path))
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
+    logging.debug(output)
+    return meta_data
 
 
 # ----> Do not edit below this line <----

--- a/fact_extractor/plugins/unpacking/generic_fs/code/generic_fs.py
+++ b/fact_extractor/plugins/unpacking/generic_fs/code/generic_fs.py
@@ -62,7 +62,8 @@ def _mount_from_boot_record(file_path, tmp_dir):
         # thus "host" loop device is used instead of filename
         k_output, return_code = execute_shell_command_get_return_code('sudo kpartx -d -v {}'.format(_get_host_loop(loop_devices)))
         execute_shell_command('sudo losetup -d {}'.format(_get_host_loop(loop_devices)))
-        return output + k_output
+        output += k_output
+        return output
 
     return output
 
@@ -70,7 +71,8 @@ def _mount_from_boot_record(file_path, tmp_dir):
 def _process_loop_device(loop_device, mount_point, target_directory, index):
     output = execute_shell_command('sudo mount -o ro -v /dev/mapper/{} {}'.format(loop_device, mount_point))
     output += execute_shell_command('sudo cp -av {}/ {}/partition_{}/'.format(mount_point, target_directory, index))
-    return output + execute_shell_command('sudo umount -v {}'.format(mount_point))
+    output += execute_shell_command('sudo umount -v {}'.format(mount_point))
+    return output
 
 
 def _extract_loop_devices(kpartx_output):

--- a/fact_extractor/plugins/unpacking/jffs2/code/jffs2.py
+++ b/fact_extractor/plugins/unpacking/jffs2/code/jffs2.py
@@ -4,7 +4,7 @@ This plugin unpacks JFFS2 filesystem images
 import logging
 import os
 
-from common_helper_process import execute_shell_command
+from common_helper_process import execute_shell_command_get_return_code
 
 NAME = 'JFFS2'
 MIME_PATTERNS = ['filesystem/jffs2', 'filesystem/jffs2-big']
@@ -18,11 +18,12 @@ def unpack_function(file_path, tmp_dir):
     '''
 
     extract_dir = os.path.join(tmp_dir, 'jffs-root')
-    output = execute_shell_command('fakeroot jefferson -v -d {} {}'.format(extract_dir, file_path)) + '\n'
-    meta_data = {'output': output}
+    output, return_code = execute_shell_command_get_return_code('fakeroot jefferson -v -d {} {}'.format(extract_dir, file_path))
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
     logging.debug(output)
     return meta_data
-
 
 # ----> Do not edit below this line <----
 def setup(unpack_tool):

--- a/fact_extractor/plugins/unpacking/patool/code/patool.py
+++ b/fact_extractor/plugins/unpacking/patool/code/patool.py
@@ -1,7 +1,9 @@
 '''
 This plugin unpacks several formats utilizing patool
 '''
-from common_helper_process import execute_shell_command
+import logging
+
+from common_helper_process import execute_shell_command_get_return_code
 
 NAME = 'PaTool'
 MIME_PATTERNS = ['application/x-lrzip', 'application/x-cpio', 'application/x-archive', 'application/x-adf',
@@ -22,9 +24,12 @@ def unpack_function(file_path, tmp_dir):
     file_path specifies the input file.
     tmp_dir should be used to store the extracted files.
     """
-    output = execute_shell_command('fakeroot patool extract --outdir {} {}'.format(tmp_dir, file_path), timeout=600)
-    return {'output': output}
-
+    output, return_code = execute_shell_command_get_return_code('fakeroot patool extract --outdir {} {}'.format(tmp_dir, file_path), timeout=600)
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
+    logging.debug(output)
+    return meta_data
 
 # ----> Do not edit below this line <----
 def setup(unpack_tool):

--- a/fact_extractor/plugins/unpacking/squashFS/code/squash_fs.py
+++ b/fact_extractor/plugins/unpacking/squashFS/code/squash_fs.py
@@ -4,7 +4,7 @@ This plugin unpacks SquashFS filesystem images
 import os
 
 from common_helper_files import get_files_in_dir
-from common_helper_process import execute_shell_command
+from common_helper_process import execute_shell_command_get_return_code
 
 THIS_FILES_DIR = os.path.dirname(os.path.abspath(__file__))
 BIN_DIR = os.path.join(THIS_FILES_DIR, '../bin')
@@ -23,13 +23,17 @@ def unpack_function(file_path, tmp_dir):
     '''
     unpack_result = dict()
     for unpacker in SQUASH_UNPACKER:
-        output = execute_shell_command('fakeroot {} -d {}/fact_extracted {}'.format(unpacker, tmp_dir, file_path))
+        output, return_code = execute_shell_command_get_return_code('fakeroot {} -d {}/fact_extracted {}'.format(unpacker, tmp_dir, file_path))
         if _unpack_success(tmp_dir):
             unpack_result['unpacking_tool'] = _get_unpacker_name(unpacker)
             unpack_result['output'] = output
+            unpack_result['return_code'] = return_code
             break
         else:
             unpack_result['{} - error'.format(_get_unpacker_name(unpacker))] = output
+            unpack_result['return_code'] = return_code
+    if unpack_result['return_code'] !=0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(unpack_result['return_code']))
     return unpack_result
 
 

--- a/fact_extractor/plugins/unpacking/squashFS/test/test_plugin_squashfs.py
+++ b/fact_extractor/plugins/unpacking/squashFS/test/test_plugin_squashfs.py
@@ -27,11 +27,11 @@ def test_unpack_success(unpack_path, expected):
 
 
 def test_not_unpackable_file():
-    empty_test_file = os.path.join(TEST_DATA_DIR, 'empty')
-    unpack_dir = TemporaryDirectory(prefix='fact_test_')
-    result = unpack_function(empty_test_file, unpack_dir)
-    assert 'sasquatch - error' in result.keys()
-    assert 'unsquashfs4-avm-be - error' in result.keys()
+    with pytest.raises(Exception):
+        empty_test_file = os.path.join(TEST_DATA_DIR, 'empty')
+        unpack_dir = TemporaryDirectory(prefix='fact_test_')
+        _ = unpack_function(empty_test_file, unpack_dir)
+
 
 
 class TestSquashUnpacker(TestUnpackerBase):

--- a/fact_extractor/plugins/unpacking/stuffit/code/sit.py
+++ b/fact_extractor/plugins/unpacking/stuffit/code/sit.py
@@ -1,7 +1,9 @@
 '''
 This plugin unpacks StuffIt files (.sit, .sitx)
 '''
-from common_helper_process import execute_shell_command
+import logging
+
+from common_helper_process import execute_shell_command_get_return_code
 
 NAME = 'StuffItFile'
 MIME_PATTERNS = ['application/x-stuffit', 'application/x-sit', 'application/x-stuffitx', 'application/x-sitx']
@@ -15,9 +17,12 @@ def unpack_function(file_path, tmp_dir):
     file_path specifies the input file.
     tmp_dir should be used to store the extracted files.
     '''
-    output = execute_shell_command('fakeroot {} -o {} {}'.format(STUFFIT_UNPACKER, tmp_dir, file_path))
-    return {'output': output}
-
+    output, return_code = execute_shell_command_get_return_code('fakeroot {} -o {} {}'.format(STUFFIT_UNPACKER, tmp_dir, file_path))
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
+    logging.debug(output)
+    return meta_data
 
 # ----> Do not edit below this line <----
 def setup(unpack_tool):

--- a/fact_extractor/plugins/unpacking/tpl/code/tpltool.py
+++ b/fact_extractor/plugins/unpacking/tpl/code/tpltool.py
@@ -1,7 +1,9 @@
+
+import logging
 import os
 from shutil import copyfile
 
-from common_helper_process import execute_shell_command
+from common_helper_process import execute_shell_command, execute_shell_command_get_return_code
 from helperFunctions.file_system import get_fact_bin_dir
 
 NAME = 'tpl-tool'
@@ -19,14 +21,14 @@ def unpack_function(file_path, tmp_dir):
     tmp_file_path = os.path.join(tmp_dir, os.path.basename(file_path))
     copyfile(file_path, tmp_file_path)
 
-    result = {}
-
-    result['output'] = execute_shell_command('fakeroot {} -x {}'.format(UNPACKER_EXECUTEABLE, tmp_file_path))
-    result['header-info'] = execute_shell_command('{} -s {}'.format(UNPACKER_EXECUTEABLE, tmp_file_path))
-
+    output, return_code = execute_shell_command_get_return_code('fakeroot {} -x {}'.format(UNPACKER_EXECUTEABLE, tmp_file_path))
+    header = execute_shell_command('{} -s {}'.format(UNPACKER_EXECUTEABLE, tmp_file_path))
     os.remove(tmp_file_path)
-
-    return result
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'header-info': header, 'return_code': return_code}
+    logging.debug(output)
+    return meta_data
 
 
 # ----> Do not edit below this line <----

--- a/fact_extractor/plugins/unpacking/trx/code/untrx.py
+++ b/fact_extractor/plugins/unpacking/trx/code/untrx.py
@@ -1,7 +1,9 @@
+import logging
+
 from os import path
 from tempfile import NamedTemporaryFile
 
-from common_helper_process.fail_safe_subprocess import execute_shell_command
+from common_helper_process.fail_safe_subprocess import execute_shell_command_get_return_code
 from helperFunctions.file_system import get_fact_bin_dir
 
 NAME = 'untrx'
@@ -43,7 +45,12 @@ def _remove_non_trx_header(source_path, target_fp, offset):
 
 
 def _unpack_trx(file_path, target_dir):
-    return execute_shell_command('fakeroot {} {} {}'.format(UNPACKER_EXECUTEABLE, file_path, target_dir))
+    output, return_code = execute_shell_command_get_return_code('fakeroot {} {} {}'.format(UNPACKER_EXECUTEABLE, file_path, target_dir))
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
+    logging.debug(output)
+    return meta_data
 
 
 # ----> Do not edit below this line <----

--- a/fact_extractor/plugins/unpacking/ubi/code/ubi_fs.py
+++ b/fact_extractor/plugins/unpacking/ubi/code/ubi_fs.py
@@ -3,7 +3,7 @@ This plugin unpacks ubi filesystem images
 '''
 import logging
 
-from common_helper_process.fail_safe_subprocess import execute_shell_command
+from common_helper_process.fail_safe_subprocess import execute_shell_command_get_return_code
 
 NAME = 'UBIFS'
 MIME_PATTERNS = ['filesystem/ubifs']
@@ -15,12 +15,13 @@ def unpack_function(file_path, tmp_dir):
     file_path specifies the input file.
     local_tmp_dir should be used to store the extracted files.
     '''
-    output = execute_shell_command('fakeroot ubireader_extract_files -v --output-dir {} {}'.format(tmp_dir, file_path)) + '\n'
+    output, return_code = execute_shell_command_get_return_code('fakeroot ubireader_extract_files -v --output-dir {} {}'.format(tmp_dir, file_path))
 
-    meta_data = {'output': output}
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
     logging.debug(output)
     return meta_data
-
 
 # ----> Do not edit below this line <----
 def setup(unpack_tool):

--- a/fact_extractor/plugins/unpacking/ubi/code/ubi_image.py
+++ b/fact_extractor/plugins/unpacking/ubi/code/ubi_image.py
@@ -1,7 +1,9 @@
 '''
 This plugin unpacks ubi images
 '''
-from common_helper_process import execute_shell_command
+import logging
+
+from common_helper_process import execute_shell_command_get_return_code
 
 NAME = 'UBI-Image'
 MIME_PATTERNS = ['firmware/ubi-image']
@@ -13,8 +15,11 @@ def unpack_function(file_path, tmp_dir):
     file_path specifies the input file.
     local_tmp_dir should be used to store the extracted files.
     '''
-    output = execute_shell_command('fakeroot ubireader_extract_images -v --output-dir {} {}'.format(tmp_dir, file_path)) + '\n'
-    meta_data = {'output': output}
+    output, return_code = execute_shell_command_get_return_code('fakeroot ubireader_extract_images -v --output-dir {} {}'.format(tmp_dir, file_path))
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
+    logging.debug(output)
     return meta_data
 
 

--- a/fact_extractor/plugins/unpacking/uefi/code/uefi.py
+++ b/fact_extractor/plugins/unpacking/uefi/code/uefi.py
@@ -1,9 +1,10 @@
 '''
 This plugin unpacks UEFI Firmware Container.
 '''
+import logging
 import os
 
-from common_helper_process import execute_shell_command
+from common_helper_process import execute_shell_command_get_return_code
 from helperFunctions.file_system import get_fact_bin_dir
 
 NAME = 'UEFI'
@@ -20,9 +21,12 @@ def unpack_function(file_path, tmp_dir):
     Optional: Return a dict with meta information
     '''
     extraction_command = 'python2 {} --superbrute --extract --output {} {}'.format(TOOL_PATH, tmp_dir, file_path)
-    output = execute_shell_command(extraction_command)
-    return {'output': output}
-
+    output, return_code = execute_shell_command_get_return_code(extraction_command)
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
+    logging.debug(output)
+    return meta_data
 
 # ----> Do not edit below this line <----
 

--- a/fact_extractor/plugins/unpacking/vxworks/code/ros.py
+++ b/fact_extractor/plugins/unpacking/vxworks/code/ros.py
@@ -1,6 +1,7 @@
+import logging
 import os
 
-from common_helper_process.fail_safe_subprocess import execute_shell_command
+from common_helper_process.fail_safe_subprocess import execute_shell_command_get_return_code
 from helperFunctions.file_system import get_fact_bin_dir
 
 NAME = 'ROSFile'
@@ -15,9 +16,12 @@ def unpack_function(file_path, tmp_dir):
     file_path specifies the input file.
     tmp_dir should be used to store the extracted files.
     '''
-    output = execute_shell_command('(cd {} && fakeroot {} --extract {})'.format(tmp_dir, TOOL_PATH, file_path))
-    return {'output': output}
-
+    output, return_code = execute_shell_command_get_return_code('(cd {} && fakeroot {} --extract {})'.format(tmp_dir, TOOL_PATH, file_path))
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
+    logging.debug(output)
+    return meta_data
 
 # ----> Do not edit below this line <----
 def setup(unpack_tool):

--- a/fact_extractor/plugins/unpacking/yaffs/code/yaffs.py
+++ b/fact_extractor/plugins/unpacking/yaffs/code/yaffs.py
@@ -1,6 +1,7 @@
+import logging
 from os import path
 
-from common_helper_process import execute_shell_command
+from common_helper_process import execute_shell_command_get_return_code
 from helperFunctions.file_system import get_fact_bin_dir
 
 NAME = 'YAFFS'
@@ -17,9 +18,12 @@ def unpack_function(file_path, tmp_dir):
     tmp_dir should be used to store the extracted files.
     '''
     unpacker = '{} -e'.format(UNYAFFS2_EXECUTEABLE) if _is_big_endian(file_path) else '{} -v'.format(UNYAFFS_EXECUTEABLE)
-    output = execute_shell_command('fakeroot {} {} {}'.format(unpacker, file_path, tmp_dir))
-    return {'output': output}
-
+    output, return_code = execute_shell_command_get_return_code('fakeroot {} {} {}'.format(unpacker, file_path, tmp_dir))
+    if return_code != 0:
+        raise Exception('Non-zero error code {} when executing shell command.'.format(return_code))
+    meta_data = {'output': output, 'return_code': return_code}
+    logging.debug(output)
+    return meta_data
 
 def _is_big_endian(file_path):
     with open(file_path, 'br') as fp:

--- a/fact_extractor/test/unit/helperFunctions/test_plugin.py
+++ b/fact_extractor/test/unit/helperFunctions/test_plugin.py
@@ -15,5 +15,5 @@ class TestHelperFunctionsPlugin(unittest.TestCase):
     def test_load_plugins(self):
         result = import_plugins('plugins.test', TEST_PLUGINS_BASE_PATH)
         imported_plugins = result.list_plugins()
-        self.assertEqual(len(imported_plugins), 1, 'worng number of plugins imported')
+        self.assertEqual(len(imported_plugins), 1, 'wrong number of plugins imported')
         self.assertEqual(imported_plugins[0], 'plugin_one', 'plugin name not correct')


### PR DESCRIPTION
The exceptions will be handled by the unpack logic, and so this should work just the same as before with some better logging. In addition, return code metadata will be made available. I also put some effort into 'standardizing' the plugins -- the ones changed now output logging and have a more unified format.

GenericFS and Sevenz seem to have more moving parts than the others, so I avoided the conversion for those two for now. I tried to prep GenericFS for the future change a little bit.