### PR TITLE
fixed double usage of unsquashfs4-avm-le in unpacker

### DIFF
--- a/fact_extractor/plugins/unpacking/squashFS/code/squash_fs.py
+++ b/fact_extractor/plugins/unpacking/squashFS/code/squash_fs.py
@@ -13,7 +13,8 @@ BIN_DIR = os.path.join(THIS_FILES_DIR, '../bin')
 NAME = 'SquashFS'
 MIME_PATTERNS = ['filesystem/squashfs']
 VERSION = '0.7'
-SQUASH_UNPACKER = ['sasquatch', BIN_DIR + '/unsquashfs4-avm-be', BIN_DIR + '/unsquashfs4-avm-le', BIN_DIR + '/unsquashfs4-avm-le']
+SQUASH_UNPACKER = ['sasquatch', BIN_DIR + '/unsquashfs4-avm-be',
+                   BIN_DIR + '/unsquashfs4-avm-le', BIN_DIR + '/unsquashfs3-multi']
 
 
 def unpack_function(file_path, tmp_dir):

--- a/fact_extractor/plugins/unpacking/squashFS/install.sh
+++ b/fact_extractor/plugins/unpacking/squashFS/install.sh
@@ -6,7 +6,9 @@ echo "------------------------------------"
 echo "   install additional sqfs tools    "
 echo "------------------------------------"
 
-sudo apt-get install -y gettext libtool-bin libtool libacl1-dev libcap-dev libc6-dev-i386 lib32ncurses5-dev gcc-multilib lib32stdc++6 gawk pkg-config
+sudo apt-get install -y bison flex gettext libtool-bin libtool libacl1-dev libcap-dev \
+                        libc6-dev-i386 lib32ncurses5-dev gcc-multilib lib32stdc++6 \
+                        gawk pkg-config
 
 sudo useradd -M makeuser
 

--- a/fact_extractor/plugins/unpacking/squashFS/test/test_plugin_squashfs.py
+++ b/fact_extractor/plugins/unpacking/squashFS/test/test_plugin_squashfs.py
@@ -1,11 +1,10 @@
 import os
 from tempfile import TemporaryDirectory
+
 import pytest
 
-from test.unit.unpacker.test_unpacker import TestUnpackerBase  # pylint: disable=wrong-import-order
-
+from test.unit.unpacker.test_unpacker import TestUnpackerBase
 from ..code.squash_fs import _get_unpacker_name, _unpack_success, unpack_function
-
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 
@@ -39,4 +38,5 @@ class TestSquashUnpacker(TestUnpackerBase):
         self.check_unpacker_selection('filesystem/squashfs', 'SquashFS')
 
     def test_extraction_sqfs(self):
-        self.check_unpacking_of_standard_unpack_set(os.path.join(TEST_DATA_DIR, 'sqfs.img'), additional_prefix_folder='fact_extracted')
+        self.check_unpacking_of_standard_unpack_set(os.path.join(TEST_DATA_DIR, 'sqfs.img'),
+                                                    additional_prefix_folder='fact_extracted')


### PR DESCRIPTION
fixed double usage of unsquashfs4-avm-le
minor refactoring
added bison and flex as dependencies for building freetz (tested on fresh ubuntu 18 mate vm)