### PR TITLE
Ignore __pycache__ folder from plugin search

### DIFF
--- a/fact_extractor/helperFunctions/plugin.py
+++ b/fact_extractor/helperFunctions/plugin.py
@@ -18,6 +18,10 @@ def _get_plugin_src_dirs(base_dir):
     plugin_dirs = get_dirs_in_dir(str(plug_in_base_path))
     plugins = []
     for plugin_path in plugin_dirs:
+        # Ignore cache directories
+        if Path(plugin_path).name == '__pycache__':
+            continue
+
         plugin_code_dir = Path(plugin_path, 'code')
         if plugin_code_dir.is_dir():
             plugins.append(str(plugin_code_dir))


### PR DESCRIPTION
This removes a warning saying that the `__pycache__` folder doesn't contain any code directory