### PR TITLE
Add disable statistics option

### DIFF
--- a/fact_extractor/config/main.cfg
+++ b/fact_extractor/config/main.cfg
@@ -3,7 +3,7 @@ blacklist = audio/mpeg, image/png, image/jpeg, image/gif, application/x-shockwav
 data_folder = /tmp/extractor
 
 [ExpertSettings]
-statistics = False
+statistics = True
 unpack_threshold = 0.8
 header_overhead = 256
 compressed_file_types = application/x-shockwave-flash, audio/mpeg, audio/ogg, image/png, image/jpeg, image/gif, video/mp4, video/ogg

--- a/fact_extractor/config/main.cfg
+++ b/fact_extractor/config/main.cfg
@@ -3,6 +3,7 @@ blacklist = audio/mpeg, image/png, image/jpeg, image/gif, application/x-shockwav
 data_folder = /tmp/extractor
 
 [ExpertSettings]
+statistics = False
 unpack_threshold = 0.8
 header_overhead = 256
 compressed_file_types = application/x-shockwave-flash, audio/mpeg, audio/ogg, image/png, image/jpeg, image/gif, video/mp4, video/ogg

--- a/fact_extractor/unpacker/unpack.py
+++ b/fact_extractor/unpacker/unpack.py
@@ -23,7 +23,12 @@ class Unpacker(UnpackBase):
         self._report_folder = Path(self.config.get('unpack', 'data_folder'), 'reports')
 
     def unpack(self, file_path):
-        binary = Path(file_path).read_bytes()
+        compute_stats = self.config.getboolean('ExpertSettings', 'statistics', fallback=True)
+
+        if compute_stats:
+            # Get the data from the initial file to compute statistics after
+            # extracting its content
+            binary = Path(file_path).read_bytes()
 
         logging.debug('Extracting {}'.format(Path(file_path).name))
 
@@ -34,8 +39,9 @@ class Unpacker(UnpackBase):
 
         extracted_files = self.move_extracted_files(extracted_files, Path(tmp_dir.name))
 
-        add_unpack_statistics(self._file_folder, meta_data)
-        get_unpack_status(file_path, binary, extracted_files, meta_data, self.config)
+        if compute_stats:
+            add_unpack_statistics(self._file_folder, meta_data)
+            get_unpack_status(file_path, binary, extracted_files, meta_data, self.config)
 
         self.cleanup(tmp_dir)
 

--- a/fact_extractor/unpacker/unpack.py
+++ b/fact_extractor/unpacker/unpack.py
@@ -23,13 +23,6 @@ class Unpacker(UnpackBase):
         self._report_folder = Path(self.config.get('unpack', 'data_folder'), 'reports')
 
     def unpack(self, file_path):
-        compute_stats = self.config.getboolean('ExpertSettings', 'statistics', fallback=True)
-
-        if compute_stats:
-            # Get the data from the initial file to compute statistics after
-            # extracting its content
-            binary = Path(file_path).read_bytes()
-
         logging.debug('Extracting {}'.format(Path(file_path).name))
 
         tmp_dir = TemporaryDirectory(prefix='fact_unpack_')
@@ -39,7 +32,9 @@ class Unpacker(UnpackBase):
 
         extracted_files = self.move_extracted_files(extracted_files, Path(tmp_dir.name))
 
+        compute_stats = self.config.getboolean('ExpertSettings', 'statistics', fallback=True)
         if compute_stats:
+            binary = Path(file_path).read_bytes()
             add_unpack_statistics(self._file_folder, meta_data)
             get_unpack_status(file_path, binary, extracted_files, meta_data, self.config)
 


### PR DESCRIPTION
In my opinion, this is especially useful when using fact_extractor as part of another script, for example to recursively extract a file's content. In some cases, it divided by 2 the time needed by fact_extractor to finish running.