### PR TITLE
Create report folder in output directory if it doesn't exist

### DIFF
--- a/fact_extractor/fact_extract.py
+++ b/fact_extractor/fact_extract.py
@@ -17,7 +17,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
+import os
 import sys
+from pathlib import Path
 
 from helperFunctions.program_setup import setup_argparser, setup_logging, load_config
 from unpacker.unpack import unpack
@@ -28,6 +30,9 @@ def main():
     config = load_config(arguments.config_file)
     setup_logging(arguments.debug, log_file=arguments.log_file, log_level=arguments.log_level)
 
+    # Make sure report folder exists some meta.json can be written
+    report_folder = Path(config.get('unpack', 'data_folder'), 'reports')
+    report_folder.mkdir(parents=True, exist_ok=True)
     unpack(arguments.FILE_PATH, config)
 
     return 0

--- a/fact_extractor/fact_extract.py
+++ b/fact_extractor/fact_extract.py
@@ -17,7 +17,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import os
 import sys
 from pathlib import Path
 

--- a/fact_extractor/unpacker/unpack.py
+++ b/fact_extractor/unpacker/unpack.py
@@ -39,7 +39,6 @@ class Unpacker(UnpackBase):
 
         self.cleanup(tmp_dir)
 
-        os.makedirs(str(self._report_folder), exist_ok=True)
         Path(self._report_folder, 'meta.json').write_text(json.dumps(meta_data, cls=ReportEncoder, indent=4))
 
         return extracted_files

--- a/fact_extractor/unpacker/unpack.py
+++ b/fact_extractor/unpacker/unpack.py
@@ -39,6 +39,7 @@ class Unpacker(UnpackBase):
 
         self.cleanup(tmp_dir)
 
+        os.makedirs(str(self._report_folder), exist_ok=True)
         Path(self._report_folder, 'meta.json').write_text(json.dumps(meta_data, cls=ReportEncoder, indent=4))
 
         return extracted_files


### PR DESCRIPTION
When running fact_extractor a non-existing directory as output location, the `report` folder doesn't seem to get created, which results in an Exception when creating the `meta.json` file.