### PR TITLE
Linux Kernel extraction, ELF output

### DIFF
--- a/fact_extractor/plugins/unpacking/linuxkernel/code/linuxkernel.py
+++ b/fact_extractor/plugins/unpacking/linuxkernel/code/linuxkernel.py
@@ -22,6 +22,7 @@ MIME_PATTERNS = [
 VERSION = '0.0.1'
 
 STRINGS_PATH = execute_shell_command('which strings').strip()
+VMLINUX_TO_ELF_PATH = execute_shell_command('which vmlinux-to-elf').strip()
 TOOL_PATHS = {}
 KERNEL_STRINGS_TO_MATCH = ['Linux version', 'jiffies', 'syscall']
 
@@ -94,6 +95,13 @@ def unpack_function(file_path, tmp_dir):
         if found:
             output += f'Found Kernel {output_file_name}\n'
             break
+
+    # The resulting output could be a variety of formats, what we want to do is rebuild it as a non-stripped ELF
+    # that is then easily analyzable in your favorite tools. Use vmlinux-to-elf for this.
+    if output_file_name:
+        cmd = f'fakeroot {VMLINUX_TO_ELF_PATH} {output_file_name} {output_file_name}.elf'
+        output += cmd + '\n'
+        output += execute_shell_command(cmd, timeout=600)
 
     return {
         'output': output

--- a/fact_extractor/plugins/unpacking/linuxkernel/install.sh
+++ b/fact_extractor/plugins/unpacking/linuxkernel/install.sh
@@ -5,5 +5,5 @@ echo "     install liblz4-tools, zstd     "
 echo "------------------------------------"
 
 sudo apt-get install -y liblz4-tool zstd
-
+sudo pip3 install --upgrade lz4 git+https://github.com/marin-m/vmlinux-to-elf
 exit 0


### PR DESCRIPTION
If a linux kernel is extracted, attempt to output usable ELF format that is easily importable in Binary Ninja/IDA/Ghidra. Uses https://github.com/marin-m/vmlinux-to-elf to accomplish this. Original extracted file is maintained alongside the .elf file.

In anticipation of questions:
- Q: if the extracted output is already a ELF file, why try to rebuild it anyway?
- A: the extracted file could be a stripped ELF, in which case it's still useful to rebuild and recover symbols from symbol table.