### PR TITLE
uboot plugin: fix UnicodeDecodeError in image_name

### DIFF
--- a/fact_extractor/plugins/unpacking/uboot/internal/uboot_container.py
+++ b/fact_extractor/plugins/unpacking/uboot/internal/uboot_container.py
@@ -98,6 +98,8 @@ class uBootHeader():
             20: 'x86_setupbin_image'}
 
     def __str__(self):
+        if self.image_name is None:
+            return ""
         return self.image_name
 
     def __init__(self):
@@ -145,4 +147,7 @@ class uBootHeader():
         else:
             raise UbootInvalidCompression
 
-        self.image_name = header[11].replace(b'\x00', b'').decode(encoding='UTF-8')
+        try:
+            self.image_name = header[11].replace(b"\x00", b"").decode(encoding="UTF-8")
+        except UnicodeDecodeError:
+            pass


### PR DESCRIPTION
This PR addresses issue #78

It seems that some uboot images don't contain UTF-8 decodeable image names (e.g., the provided `US_W312AV1.0BR_V2.0.0.3(1330)_EN_TDE.bin` in issue #78). Currently, this leads to an UnicodeDecodeError, which is addressed by this PR.