### PR TITLE
FACT-extractor on current Kali Linux 2021-02

### DIFF
--- a/fact_extractor/install.py
+++ b/fact_extractor/install.py
@@ -41,9 +41,10 @@ PROGRAM_DESCRIPTION = 'Firmware Analysis and Comparison Tool (FACT) Extractor in
 BIONIC_CODE_NAMES = ['bionic', 'tara', 'tessa', 'tina', 'disco']
 XENIAL_CODE_NAMES = ['xenial', 'yakkety', 'sarah', 'serena', 'sonya', 'sylvia']
 FOCAL_CODE_NAMES = ['focal', 'ulyana']
+KALI_CODE_NAMES = ['kali-rolling']
 
 # Compatible Debian/Kali releases
-BUSTER_CODE_NAMES = ['buster', 'stretch', 'kali-rolling']
+BUSTER_CODE_NAMES = ['buster', 'stretch']
 BULLSEYE_CODE_NAMES = ['bullseye']
 
 
@@ -84,6 +85,9 @@ def check_distribution():
     if codename in BUSTER_CODE_NAMES:
         logging.debug('Debian 10/Kali detected')
         return 'buster'
+    if codename in KALI_CODE_NAMES:
+        logging.debug('Kali detected')
+        return 'kali'
     if codename in BULLSEYE_CODE_NAMES:
         logging.debug('Debian 11 detected')
         return 'bullseye'

--- a/fact_extractor/install/common.py
+++ b/fact_extractor/install/common.py
@@ -28,6 +28,11 @@ DEPENDENCIES = {
             'testresources'
         ]
     },
+    'kali': {
+        'pip3': [
+            'testresources'
+        ]
+    },
     'bullseye': {
         'pip3': [
             'testresources'

--- a/fact_extractor/install/unpacker.py
+++ b/fact_extractor/install/unpacker.py
@@ -249,7 +249,7 @@ def _install_freetz():
                 'sudo su makeuser -c "export PATH=$(pwd):$PATH && umask 0022 && make -j$(nproc) tools"',
                 f'sudo chmod -R 777 {build_directory}',
                 f'sudo chown -R {current_user} {build_directory}',
-                'sudo cp tools/find-squashfs tools/unpack-kernel tools/freetz_bin_functions tools/unlzma tools/sfk '
+                'cp tools/find-squashfs tools/unpack-kernel tools/freetz_bin_functions tools/unlzma tools/sfk '
                 f'tools/unsquashfs4-avm-be tools/unsquashfs4-avm-le tools/unsquashfs3-multi {BIN_DIR}',
                 'sudo userdel makeuser'
             ])


### PR DESCRIPTION
During my last tests I was not able to install FACt-extractor on a current Kali Linux. It ended with multiple errors:

```
└─$ sudo python3 ./install.py 
[2021-08-31 10:43:52][install][INFO]: FACT_extractor Installer 0.2
[2021-08-31 10:43:52][common][INFO]: Updating package lists
[2021-08-31 10:43:54][install][INFO]: Installing build-essential automake autoconf libtool python3 python3-dev python-wheel-common
[2021-08-31 10:43:54][install][INFO]: Installing pytest pytest-cov
[2021-08-31 10:43:56][install][INFO]: Installing testresources
[2021-08-31 10:43:57][install][INFO]: Removing python-lzma
[2021-08-31 10:43:57][install][INFO]: Removing jefferson
[2021-08-31 10:43:57][install][INFO]: Installing libjpeg-dev liblzma-dev liblzo2-dev zlib1g-dev unzip libffi-dev libfuzzy-dev fakeroot python3-opengl mtd-utils gzip bzip2 tar arj lhasa cabextract cramfsswap squashfs-tools zlib1g-dev liblzma-dev liblzo2-dev xvfb libcapstone3 libcapstone-dev lrzip cpio unadf rpm2cpio lzop lhasa cabextract zpaq libchm-dev arj xdms rzip lzip unalz unrar unzip gzip nomarch flac unace sharutils unar bison flex gettext libtool-bin libtool libacl1-dev libcap-dev libc6-dev-i386 lib32ncurses5-dev gcc-multilib lib32stdc++6 gawk pkg-config
Traceback (most recent call last):
  File "/home/m1k3/git-repos/fact_extractor_orig/fact_extractor/./install.py", line 110, in <module>
    sys.exit(main())
  File "/home/m1k3/git-repos/fact_extractor_orig/fact_extractor/./install.py", line 104, in main
    unpacker(distribution)
  File "/home/m1k3/git-repos/fact_extractor_orig/fact_extractor/install/unpacker.py", line 186, in main
    install_dependencies(DEPENDENCIES['common'])
  File "/home/m1k3/git-repos/fact_extractor_orig/fact_extractor/install/unpacker.py", line 169, in install_dependencies
    apt_install_packages(*apt)
  File "/home/m1k3/git-repos/fact_extractor_orig/fact_extractor/helperFunctions/install.py", line 76, in apt_install_packages
    return run_shell_command_raise_on_return_code('sudo -E apt-get install -y {}'.format(' '.join(args)), 'Error in installation of package(s) {}'.format(' '.join(args)), True)
  File "/home/m1k3/git-repos/fact_extractor_orig/fact_extractor/helperFunctions/install.py", line 51, in run_shell_command_raise_on_return_code
    raise InstallationError(error)
helperFunctions.install.InstallationError: Error in installation of package(s) libjpeg-dev liblzma-dev liblzo2-dev zlib1g-dev unzip libffi-dev libfuzzy-dev fakeroot python3-opengl mtd-utils gzip bzip2 tar arj lhasa cabextract cramfsswap squashfs-tools zlib1g-dev liblzma-dev liblzo2-dev xvfb libcapstone3 libcapstone-dev lrzip cpio unadf rpm2cpio lzop lhasa cabextract zpaq libchm-dev arj xdms rzip lzip unalz unrar unzip gzip nomarch flac unace sharutils unar bison flex gettext libtool-bin libtool libacl1-dev libcap-dev libc6-dev-i386 lib32ncurses5-dev gcc-multilib lib32stdc++6 gawk pkg-config
Paketlisten werden gelesen…
Abhängigkeitsbaum wird aufgebaut…
Statusinformationen werden eingelesen…
E: Paket libcapstone3 kann nicht gefunden werden.
```

I have started fixing the dependencies and get it up and running again with the attached modifications:

```
└─$ sudo python3 ./install.py                                                                                                                            1 ⨯
[sudo] Passwort für m1k3: 
[2021-08-31 10:39:07][install][INFO]: FACT_extractor Installer 0.2
[2021-08-31 10:39:07][common][INFO]: Updating package lists
[2021-08-31 10:39:09][install][INFO]: Installing build-essential automake autoconf libtool python3 python3-dev python-wheel-common
[2021-08-31 10:39:09][install][INFO]: Installing pytest pytest-cov
[2021-08-31 10:39:11][install][INFO]: Installing testresources
[2021-08-31 10:39:12][install][INFO]: Removing python-lzma
[2021-08-31 10:39:12][install][INFO]: Removing jefferson
[2021-08-31 10:39:12][install][INFO]: Installing libjpeg-dev liblzma-dev liblzo2-dev zlib1g-dev unzip libffi-dev libfuzzy-dev fakeroot python3-opengl mtd-utils gzip bzip2 tar arj lhasa cabextract cramfsswap squashfs-tools zlib1g-dev liblzma-dev liblzo2-dev xvfb libcapstone-dev lrzip cpio unadf rpm2cpio lzop lhasa cabextract zpaq libchm-dev arj xdms rzip lzip unalz unrar unzip gzip nomarch flac unace sharutils unar bison flex gettext libtool-bin libtool libacl1-dev libcap-dev libc6-dev-i386 lib32ncurses5-dev gcc-multilib lib32stdc++6 gawk pkg-config
[2021-08-31 10:39:12][install][INFO]: Installing pluginbase git+https://github.com/armbues/python-entropy git+https://github.com/fkie-cad/common_helper_unpacking_classifier.git git+https://github.com/fkie-cad/fact_helper_file.git patool archmage pyqtgraph capstone cstruct python-lzo numpy scipy git+https://github.com/jrspruitt/ubi_reader@v0.6.3-master
[2021-08-31 10:39:29][install][INFO]: Installing devttys0/sasquatch
[2021-08-31 10:39:38][install][INFO]: Installing ReFirmLabs/binwalk
[2021-08-31 10:39:47][install][INFO]: Installing svidovich/jefferson-3
[2021-08-31 10:39:48][install][INFO]: Installing p7zip-full libqt5opengl5 python3-pyqt5 python3-pyqt5.qtopengl openjdk-11-jdk firmware-mod-kit libcapstone4
[2021-08-31 10:40:45][unpacker][INFO]: Kali Linux - copy binaries from installed firmware-mod-kit ...
[2021-08-31 10:40:45][unpacker][INFO]: Kali linux detected - Not installing Freetz
[2021-08-31 10:40:45][unpacker][INFO]: Installing plugins
[2021-08-31 10:40:45][unpacker][INFO]: Running ../plugins/unpacking/raw/install.sh
[2021-08-31 10:40:47][unpacker][INFO]: Running ../plugins/unpacking/intel_hex/install.sh
[2021-08-31 10:40:48][unpacker][INFO]: Running ../plugins/unpacking/linuxkernel/install.sh
[2021-08-31 10:40:54][unpacker][INFO]: Running ../plugins/unpacking/uefi/install.sh
[2021-08-31 10:40:58][unpacker][INFO]: Running ../plugins/unpacking/generic_fs/install.sh
[2021-08-31 10:41:14][unpacker][INFO]: Running ../plugins/unpacking/srec/install.sh
[2021-08-31 10:41:16][unpacker][INFO]: Running ../plugins/unpacking/dji/install.sh
[2021-08-31 10:41:36][unpacker][INFO]: Running ../plugins/unpacking/boschtool/install.sh
[2021-08-31 10:41:44][unpacker][INFO]: Running ../plugins/unpacking/yaffs/install.sh
[2021-08-31 10:41:46][unpacker][INFO]: Running ../plugins/unpacking/mikrotik/install.sh
[2021-08-31 10:41:48][unpacker][INFO]: Running ../plugins/unpacking/sevenz/install.sh
[2021-08-31 10:42:28][unpacker][INFO]: Running ../plugins/unpacking/hp/install.sh
[2021-08-31 10:42:30][unpacker][INFO]: add rules to sudo...                                                                                                                                                                                  
[2021-08-31 10:42:30][install][INFO]: installation complete  
```

Freetz needs some extra work.