### PR TITLE
Pin binwalk

### DIFF
--- a/fact_extractor/install/unpacker.py
+++ b/fact_extractor/install/unpacker.py
@@ -144,6 +144,7 @@ DEPENDENCIES = {
             'patool',
             'archmage',
             # binwalk
+            'git+https://github.com/ReFirmLabs/binwalk@v2.3.2',
             'pyqtgraph',
             'capstone',
             'cstruct==1.8',
@@ -154,7 +155,6 @@ DEPENDENCIES = {
         ],
         'github': [
             ('kartone/sasquatch', ['./build.sh']),
-            ('ReFirmLabs/binwalk@v2.3.2', ['sudo python3 setup.py install']),
             ('svidovich/jefferson-3', ['sudo python3 setup.py install']),
             ('rampageX/firmware-mod-kit', ['(cd src && sh configure && make)', 'cp src/yaffs2utils/unyaffs2 src/untrx src/tpl-tool/src/tpl-tool ../../bin/'])
         ]

--- a/fact_extractor/install/unpacker.py
+++ b/fact_extractor/install/unpacker.py
@@ -154,7 +154,7 @@ DEPENDENCIES = {
         ],
         'github': [
             ('kartone/sasquatch', ['./build.sh']),
-            ('ReFirmLabs/binwalk', ['sudo python3 setup.py install']),
+            ('ReFirmLabs/binwalk@v2.3.2', ['sudo python3 setup.py install']),
             ('svidovich/jefferson-3', ['sudo python3 setup.py install']),
             ('rampageX/firmware-mod-kit', ['(cd src && sh configure && make)', 'cp src/yaffs2utils/unyaffs2 src/untrx src/tpl-tool/src/tpl-tool ../../bin/'])
         ]


### PR DESCRIPTION
Pin binwalk dependency to version 2.3.2 before `--run-as-root` and current test fails.