### PR TITLE
Add timeout command to binwalk call. Related to FACT_core #820

### DIFF
--- a/fact_extractor/plugins/unpacking/generic_carver/code/generic_carver.py
+++ b/fact_extractor/plugins/unpacking/generic_carver/code/generic_carver.py
@@ -22,7 +22,7 @@ def unpack_function(file_path, tmp_dir):
     '''
 
     logging.debug('File Type unknown: execute binwalk on {}'.format(file_path))
-    output = execute_shell_command(f'binwalk --extract --carve --signature --directory  {tmp_dir} {file_path}')
+    output = execute_shell_command(f'timeout 580 binwalk --extract --carve --signature --directory  {tmp_dir} {file_path}')
 
     drop_underscore_directory(tmp_dir)
     return {'output': output, 'filter_log': ArchivesFilter(tmp_dir).remove_false_positive_archives()}


### PR DESCRIPTION
Timeout is set to 580 as the docker image has a 600 seconds timeout, so 580 seconds should be a safe number so partial results could be extracted.