### PR TITLE
Added path sanitization and fix for rampageX/firmware-mod-kit

### DIFF
--- a/.github/workflows/Lintly-Flake8.yml
+++ b/.github/workflows/Lintly-Flake8.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: grantmcconnaughey/lintly-flake8-github-action@v1.0
+      - uses: grantmcconnaughey/lintly-flake8-github-action@master
         with:
           # The GitHub API token to create reviews with
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/fact_extractor/helperFunctions/file_system.py
+++ b/fact_extractor/helperFunctions/file_system.py
@@ -33,3 +33,10 @@ def file_is_empty(file_path) -> bool:
         return Path(file_path).stat().st_size == 0
     except (FileNotFoundError, PermissionError, OSError, RuntimeError):
         return False
+
+
+def file_name_sanitize(file_path) -> str:
+    '''
+    Returns file path without directory traversal
+    '''
+    return file_path.replace('../', '')

--- a/fact_extractor/install/unpacker.py
+++ b/fact_extractor/install/unpacker.py
@@ -156,7 +156,7 @@ DEPENDENCIES = {
         'github': [
             ('kartone/sasquatch', ['./build.sh']),
             ('svidovich/jefferson-3', ['sudo python3 setup.py install']),
-            ('rampageX/firmware-mod-kit', ['(cd src && sh configure && make)', 'cp src/yaffs2utils/unyaffs2 src/untrx src/tpl-tool/src/tpl-tool ../../bin/'])
+            ('rampageX/firmware-mod-kit', ['(cd src && make)', 'cp src/yaffs2utils/unyaffs2 src/untrx src/tpl-tool/src/tpl-tool ../../bin/'])
         ]
     }
 }

--- a/fact_extractor/test/unit/helperFunctions/test_file_system.py
+++ b/fact_extractor/test/unit/helperFunctions/test_file_system.py
@@ -3,7 +3,7 @@ import unittest
 
 from common_helper_files import get_files_in_dir
 from helperFunctions.file_system import (
-    file_is_empty, get_fact_bin_dir, get_src_dir, get_test_data_dir
+    file_is_empty, get_fact_bin_dir, get_src_dir, get_test_data_dir, file_name_sanitize
 )
 
 
@@ -38,6 +38,10 @@ class TestFileSystemHelpers(unittest.TestCase):
         self.assertTrue(file_is_empty('{}/zero_byte'.format(get_test_data_dir())), 'file is empty but stated differently')
         self.assertFalse(file_is_empty('{}/get_files_test/testfile1'.format(get_test_data_dir())), 'file not empty but stated differently')
         self.assertFalse(file_is_empty(os.path.join(get_test_data_dir(), 'broken_link')), 'Broken link is not empty')
+
+    def test_sanitize_file_name(self):
+        self.assertEqual(file_name_sanitize('../../../../a/b/c/d'), 'a/b/c/d', 'file was not sanitized')
+        self.assertEqual(file_name_sanitize('dir/../../../../a/b/c/d'), 'dir/a/b/c/d', 'file was not sanitized')
 
     def test_file_is_zero_broken_link(self):
         self.assertFalse(file_is_empty(os.path.join(get_test_data_dir(), 'broken_link')), 'Broken link is not empty')


### PR DESCRIPTION
Changes in `rampageX/firmware-mod-kit` [this PR](https://github.com/rampageX/firmware-mod-kit/commit/05aa52d08a5b10792dd2dfe1def689a5bc84e026) removed the configure file, which is no longer needed. But it broke the build for fact.

Additionally we've added a general function to sanitize path names.