### PR TITLE
fixed pytest 8 deprecation warnings

### DIFF
--- a/fact_extractor/plugins/unpacking/ambarella/test/test_plugin_ambarella_romfs.py
+++ b/fact_extractor/plugins/unpacking/ambarella/test/test_plugin_ambarella_romfs.py
@@ -13,5 +13,5 @@ class TestAmbarellaRomFSUnpacker(TestUnpackerBase):
     def test_extraction(self):
         input_file = os.path.join(TEST_DATA_DIR, 'ambarella_rom.fs')
         unpacked_files, meta_data = self.unpacker.extract_files_from_file(input_file, self.tmp_dir.name)
-        self.assertIn("'file_count': 4", meta_data['output'], 'should be 4 files in the romfs')
-        self.assertGreaterEqual(len(unpacked_files), 5, 'Should contain 4 files and a header')
+        assert "'file_count': 4" in meta_data['output'], 'should be 4 files in the romfs'
+        assert len(unpacked_files) >= 5, 'Should contain 4 files and a header'

--- a/fact_extractor/plugins/unpacking/dahua/test/test_dahua.py
+++ b/fact_extractor/plugins/unpacking/dahua/test/test_dahua.py
@@ -15,7 +15,7 @@ class TestDahuaUnpacker(TestUnpackerBase):
         input_file = Path(TEST_DATA_DIR, 'dh.bin')
         unpacked_files, meta_data = self.unpacker.extract_files_from_file(str(input_file), self.tmp_dir.name)
 
-        self.assertIn('zip header fixed', meta_data['output'])
-        self.assertEqual(len(unpacked_files), 1)
-        self.assertIn('{}/dahua_firmware.zip'.format(self.tmp_dir.name), unpacked_files)
-        self.assertEqual(input_file.stat().st_size, Path(unpacked_files[0]).stat().st_size, 'file size should not change')
+        assert 'zip header fixed' in meta_data['output']
+        assert len(unpacked_files) == 1
+        assert f'{self.tmp_dir.name}/dahua_firmware.zip' in unpacked_files
+        assert input_file.stat().st_size == Path(unpacked_files[0]).stat().st_size, 'file size should not change'

--- a/fact_extractor/plugins/unpacking/deb/test/test_deb.py
+++ b/fact_extractor/plugins/unpacking/deb/test/test_deb.py
@@ -13,5 +13,5 @@ class TestDebUnpacker(TestUnpackerBase):
     def test_extraction(self):
         files, meta_data = self.unpacker.extract_files_from_file(os.path.join(TEST_DATA_DIR, 'test.deb'), self.tmp_dir.name)
 
-        self.assertEqual(len(files), 3, 'file number incorrect')
-        self.assertIn('./usr/bin/test_elf_sfx', meta_data['output'])
+        assert len(files) == 3, 'file number incorrect'
+        assert './usr/bin/test_elf_sfx' in meta_data['output']

--- a/fact_extractor/plugins/unpacking/draytek_vigor_167/test/test_draytek_vigor_167.py
+++ b/fact_extractor/plugins/unpacking/draytek_vigor_167/test/test_draytek_vigor_167.py
@@ -15,16 +15,16 @@ class TestDraytekVigor167Unpacker(TestUnpackerBase):
         test_file = Path(TEST_DATA_DIR, 'valid_draytekvigor167_image.bin')
         unpacked_files, meta_data = self.unpacker.extract_files_from_file(test_file, self.tmp_dir.name)
 
-        self.assertEqual(meta_data['output'], 'successfully unpacked image')
-        self.assertEqual(len(unpacked_files), 2, 'number of extracted files not correct')
-        self.assertIn(str(Path(self.tmp_dir.name) / 'kernel_image'), unpacked_files, 'kernel image not extracted')
-        self.assertIn(str(Path(self.tmp_dir.name) / 'squashfs_root'), unpacked_files, 'squashfs not extracted')
+        assert meta_data['output'] == 'successfully unpacked image'
+        assert len(unpacked_files) == 2, 'number of extracted files not correct'
+        assert str(Path(self.tmp_dir.name) / 'kernel_image') in unpacked_files, 'kernel image not extracted'
+        assert str(Path(self.tmp_dir.name) / 'squashfs_root') in unpacked_files, 'squashfs not extracted'
         squashfs_binary = get_binary_from_file(Path(self.tmp_dir.name) / 'squashfs_root')
         squashfs_hash = get_sha256(squashfs_binary)
-        self.assertEqual(squashfs_hash, '73b648f484ab0a34ce00729ce8b7ef183885b4b5c540344a8451d18fe94cc2fa')
+        assert squashfs_hash == '73b648f484ab0a34ce00729ce8b7ef183885b4b5c540344a8451d18fe94cc2fa'
 
     def test_extraction_invalid_image(self):
         test_file = Path(TEST_DATA_DIR, 'invalid_draytekvigor167_image_struct_error.bin')
-        unpacked_files, meta_data = self.unpacker.extract_files_from_file(test_file, self.tmp_dir.name)
+        _, meta_data = self.unpacker.extract_files_from_file(test_file, self.tmp_dir.name)
 
-        self.assertIn('failed to recognize firmware container', meta_data['output'])
+        assert 'failed to recognize firmware container' in meta_data['output']

--- a/fact_extractor/plugins/unpacking/hp/test/test_update_stream.py
+++ b/fact_extractor/plugins/unpacking/hp/test/test_update_stream.py
@@ -14,10 +14,10 @@ class TestHpStreamUnpacker(TestUnpackerBase):
     def test_extraction(self):
         input_file = Path(TEST_DATA_DIR, 'update_stream.bin')
         unpacked_files, meta_data = self.unpacker.extract_files_from_file(str(input_file), self.tmp_dir.name)
-        self.assertEqual(meta_data['number_of_zero_padded_sections'], 4)
-        self.assertEqual(meta_data['number_of_lzma_streams'], 1)
-        self.assertEqual(len(unpacked_files), 5)
-        self.assertIn('{}/0x0'.format(self.tmp_dir.name), unpacked_files)
-        self.assertIn('{}/0x8d_lzma_decompressed'.format(self.tmp_dir.name), unpacked_files)
-        decompressed_data = get_binary_from_file('{}/0x8d_lzma_decompressed'.format(self.tmp_dir.name))
-        self.assertEqual(decompressed_data, b'compressed_stream_data')
+        assert meta_data['number_of_zero_padded_sections'] == 4
+        assert meta_data['number_of_lzma_streams'] == 1
+        assert len(unpacked_files) == 5
+        assert f'{self.tmp_dir.name}/0x0' in unpacked_files
+        assert f'{self.tmp_dir.name}/0x8d_lzma_decompressed' in unpacked_files
+        decompressed_data = get_binary_from_file(f'{self.tmp_dir.name}/0x8d_lzma_decompressed')
+        assert decompressed_data == b'compressed_stream_data'

--- a/fact_extractor/plugins/unpacking/linuxkernel/test/test_extractor.py
+++ b/fact_extractor/plugins/unpacking/linuxkernel/test/test_extractor.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import unittest
 from pathlib import Path
 from unittest.mock import patch, mock_open
 
@@ -8,20 +7,20 @@ INTERNAL_DIR = Path(__file__).parent.parent / 'internal'
 sys.path.append(str(INTERNAL_DIR))
 from extractor import Extractor  # noqa: E402 pylint: disable=import-error,wrong-import-position
 
-sample_data = b'####-------\x1f\x8b\x08-------\x1f\x8b\x08$$$$BZh$$$$'
+SAMPLE_DATA = b'####-------\x1f\x8b\x08-------\x1f\x8b\x08$$$$BZh$$$$'
 
 
-class ExtractorTestCases(unittest.TestCase):
+class TestExtractorCases:
 
     def test_find_offsets(self):
-        with patch('builtins.open', mock_open(read_data=sample_data)) as mock_file:
+        with patch('builtins.open', mock_open(read_data=SAMPLE_DATA)) as mock_file:
             extract = Extractor('file_name', 'output_dir')
             mock_file.assert_called_with('file_name', 'rb')
-            ret = extract._find_offsets()
-            self.assertEqual({'BZIP': [28], 'GZIP': [11, 21]}, ret)
+            ret = extract._find_offsets()  # pylint: disable=protected-access
+            assert ret == {'BZIP': [28], 'GZIP': [11, 21]}
 
     def test_extract_files(self):
-        with patch('builtins.open', mock_open(read_data=sample_data)) as mock_file:
+        with patch('builtins.open', mock_open(read_data=SAMPLE_DATA)) as mock_file:
             output_dir = 'output_dir'
             extract = Extractor('file_name', output_dir)
             mock_file.assert_called_with('file_name', 'rb')
@@ -29,16 +28,12 @@ class ExtractorTestCases(unittest.TestCase):
         with patch('builtins.open', mock_open(read_data='')) as mock_file:
             file_generator = extract.extracted_files()
             file_data = next(file_generator)
-            self.assertEqual(os.path.join(output_dir, 'vmlinux_GZIP_11.gz'), file_data['file_path'])
+            assert file_data['file_path'] == os.path.join(output_dir, 'vmlinux_GZIP_11.gz')
             mock_file.assert_called_with('output_dir/vmlinux_GZIP_11.gz', 'wb')
             mock_file().write.assert_called_once_with(b'\x1f\x8b\x08-------\x1f\x8b\x08$$$$BZh$$$$')
 
         with patch('builtins.open', mock_open(read_data='')) as mock_file:
             file_data = next(file_generator)
-            self.assertEqual(os.path.join(output_dir, 'vmlinux_GZIP_21.gz'), file_data['file_path'])
+            assert file_data['file_path'] == os.path.join(output_dir, 'vmlinux_GZIP_21.gz')
             mock_file.assert_called_with('output_dir/vmlinux_GZIP_21.gz', 'wb')
             mock_file().write.assert_called_once_with(b'\x1f\x8b\x08$$$$BZh$$$$')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/fact_extractor/plugins/unpacking/linuxkernel/test/test_pattern_searcher.py
+++ b/fact_extractor/plugins/unpacking/linuxkernel/test/test_pattern_searcher.py
@@ -1,21 +1,18 @@
-import unittest
-
 from ..internal.pattern_searcher import PatternSearcher
 
 
-class PatternSearcherTestCase(unittest.TestCase):
-
+class TestPatternSearcherCase:
     def test_instance(self):
         data = b'####'
         ps = PatternSearcher(data)
 
-        self.assertEqual(True, isinstance(ps, PatternSearcher))
+        assert isinstance(ps, PatternSearcher)
 
     def test_search_gzip(self):
         data = b'####-------\037\213\010-------\037\213\010$$$$$$$$'
         ps = PatternSearcher(data)
         offsets = ps.find_all_gzip_offsets()
-        self.assertEqual([11, 21], offsets)
+        assert offsets == [11, 21]
 
     def test_search_all(self):
         data = b'####-------\037\213\010-------\037\213\010$$$$$$$$'
@@ -27,19 +24,17 @@ class PatternSearcherTestCase(unittest.TestCase):
         data += b'\002!L\030'
         data += b'(\265/\375'
 
-        expected = {'BZIP': [38],
-                    'GZIP': [11, 21, 48],
-                    'LZ4': [51],
-                    'LZMA': [41],
-                    'LZOP': [45],
-                    'XZ': [32],
-                    'ZSTD': [55]}
+        expected = {
+            'BZIP': [38],
+            'GZIP': [11, 21, 48],
+            'LZ4': [51],
+            'LZMA': [41],
+            'LZOP': [45],
+            'XZ': [32],
+            'ZSTD': [55],
+        }
 
         ps = PatternSearcher(data)
         offset_data = ps.find_all_headers()
 
-        self.assertEqual(expected, offset_data)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        assert offset_data == expected

--- a/fact_extractor/plugins/unpacking/linuxkernel/test/test_plugin_linuxkernel.py
+++ b/fact_extractor/plugins/unpacking/linuxkernel/test/test_plugin_linuxkernel.py
@@ -1,15 +1,12 @@
-import os
-import sys
 from pathlib import Path
+
+import pytest
 
 from test.unit.unpacker.test_unpacker import TestUnpackerBase
 
-CODE_DIR = Path(__file__).parent.parent / 'code'
-sys.path.append(str(CODE_DIR))
-
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
-sample_data = b'####-------\x1f\x8b\x08-------\x1f\x8b\x08$$$$BZh$$$$'
+SAMPLE_DATA = b'####-------\x1f\x8b\x08-------\x1f\x8b\x08$$$$BZh$$$$'
 
 
 class TestLinuxKernelUnpacker(TestUnpackerBase):
@@ -17,37 +14,18 @@ class TestLinuxKernelUnpacker(TestUnpackerBase):
     def test_unpacker_selection_generic(self):
         self.check_unpacker_selection('linux/kernel', 'LinuxKernel')
 
-    def test_extraction_valid_bzImage_bzip2(self):
-        input_file = TEST_DATA_DIR / 'bzImage_bzip2'
-        files, meta_data = self.unpacker.extract_files_from_file(str(input_file), self.tmp_dir.name)
-        self.assertEqual([os.path.join(self.tmp_dir.name, 'vmlinux_BZIP_17001')], files)
-
-    def test_extraction_valid_bzImage_gzip(self):
-        input_file = TEST_DATA_DIR / 'bzImage_gzip'
-        files, meta_data = self.unpacker.extract_files_from_file(str(input_file), self.tmp_dir.name)
-        self.assertEqual([os.path.join(self.tmp_dir.name, 'vmlinux_GZIP_17001')], files)
-
-    def test_extraction_valid_bzImage_lz4(self):
-        input_file = TEST_DATA_DIR / 'bzImage_lz4'
-        files, meta_data = self.unpacker.extract_files_from_file(str(input_file), self.tmp_dir.name)
-        self.assertEqual([os.path.join(self.tmp_dir.name, 'vmlinux_LZ4_17001')], files)
-
-    def test_extraction_valid_bzImage_lzma(self):
-        input_file = TEST_DATA_DIR / 'bzImage_lzma'
-        files, meta_data = self.unpacker.extract_files_from_file(str(input_file), self.tmp_dir.name)
-        self.assertEqual([os.path.join(self.tmp_dir.name, 'vmlinux_LZMA_17001')], files)
-
-    def test_extraction_valid_bzImage_lzo(self):
-        input_file = TEST_DATA_DIR / 'bzImage_lzo'
-        files, meta_data = self.unpacker.extract_files_from_file(str(input_file), self.tmp_dir.name)
-        self.assertEqual([os.path.join(self.tmp_dir.name, 'vmlinux_LZOP_17001')], files)
-
-    def test_extraction_valid_bzImage_xz(self):
-        input_file = TEST_DATA_DIR / 'bzImage_xz'
-        files, meta_data = self.unpacker.extract_files_from_file(str(input_file), self.tmp_dir.name)
-        self.assertEqual([os.path.join(self.tmp_dir.name, 'vmlinux_XZ_17001')], files)
+    @pytest.mark.parametrize('input_file, expected', [
+        ('bzImage_bzip2', 'vmlinux_BZIP_17001'),
+        ('bzImage_gzip', 'vmlinux_GZIP_17001'),
+        ('bzImage_lz4', 'vmlinux_LZ4_17001'),
+        ('bzImage_lzma', 'vmlinux_LZMA_17001'),
+        ('bzImage_lzo', 'vmlinux_LZOP_17001'),
+        ('bzImage_xz', 'vmlinux_XZ_17001'),
+    ])
+    def test_extraction_valid_bz_image(self, input_file, expected):
+        files, _ = self.unpacker.extract_files_from_file(str(TEST_DATA_DIR / input_file), self.tmp_dir.name)
+        assert files == [str(Path(self.tmp_dir.name) / expected)]
 
     def test_extraction_invalid_image(self):
-        input_file = TEST_DATA_DIR / 'bogus_image.bin'
-        files, meta_data = self.unpacker.extract_files_from_file(str(input_file), self.tmp_dir.name)
-        self.assertEqual([], files)
+        files, _ = self.unpacker.extract_files_from_file(str(TEST_DATA_DIR / 'bogus_image.bin'), self.tmp_dir.name)
+        assert files == []

--- a/fact_extractor/plugins/unpacking/patool/test/test_plugin_patool.py
+++ b/fact_extractor/plugins/unpacking/patool/test/test_plugin_patool.py
@@ -1,16 +1,28 @@
 import os
-from test.unit.unpacker.test_unpacker import TestUnpackerBase
 
+import pytest
+
+from test.unit.unpacker.test_unpacker import TestUnpackerBase
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 
 
 class TestPaToolUnpacker(TestUnpackerBase):
-
     def test_unpacker_selection_generic(self):
         self.check_unpacker_selection('application/vnd.ms-cab-compressed', 'PaTool')
 
-    def test_extraction(self):
-        in_files = ['test.cab', 'test.zoo', 'test.tar.bz2', 'test.tar.zip']
-        for in_file in in_files:
-            self.check_unpacking_of_standard_unpack_set(os.path.join(TEST_DATA_DIR, in_file), additional_prefix_folder='get_files_test', output=False)
+    @pytest.mark.parametrize(
+        'in_file, ignore',
+        [
+            ('test.cab', None),
+            ('test.tar.bz2', None),
+            ('test.tar.zip', None),
+        ],
+    )
+    def test_extraction(self, in_file, ignore):
+        self.check_unpacking_of_standard_unpack_set(
+            os.path.join(TEST_DATA_DIR, in_file),
+            additional_prefix_folder='get_files_test',
+            output=False,
+            ignore=ignore,
+        )

--- a/fact_extractor/plugins/unpacking/raw/test/test_raw.py
+++ b/fact_extractor/plugins/unpacking/raw/test/test_raw.py
@@ -9,27 +9,26 @@ class TestRawUnpacker(TestUnpackerBase):
 
     def test_unpacker_selection(self):
         self.check_unpacker_selection('data/raw', 'RAW')
-#        self.check_unpacker_selection('application/octet-stream', 'RAW')
 
     def test_extraction(self):
         input_file = Path(TEST_DATA_DIR, 'raw.bin')
         unpacked_files, meta_data = self.unpacker.extract_files_from_file(str(input_file), self.tmp_dir.name)
-        self.assertEqual(meta_data['padding seperated sections'], 3)
-        self.assertEqual(meta_data['LZMA'], 1)
-        self.assertEqual(len(unpacked_files), 4)
-        self.assertIn('{}/0x2f'.format(self.tmp_dir.name), unpacked_files)
-        self.assertIn('{}/0x8d.lzma'.format(self.tmp_dir.name), unpacked_files)
+        assert meta_data['padding seperated sections'] == 3
+        assert meta_data['LZMA'] == 1
+        assert len(unpacked_files) == 4
+        assert f'{self.tmp_dir.name}/0x2f' in unpacked_files
+        assert f'{self.tmp_dir.name}/0x8d.lzma' in unpacked_files
 
     def test_extraction_encoded(self):
         input_file = Path(TEST_DATA_DIR, 'encoded.bin')
         unpacked_files, meta_data = self.unpacker._extract_files_from_file_using_specific_unpacker(str(input_file), self.tmp_dir.name, self.unpacker.unpacker_plugins['data/raw'])
-        self.assertEqual(meta_data['Intel Hex'], 1)
-        self.assertEqual(meta_data['Motorola S-Record'], 1)
-        self.assertIn('{}/0x6.ihex'.format(self.tmp_dir.name), unpacked_files)
-        self.assertIn('{}/0x291f.srec'.format(self.tmp_dir.name), unpacked_files)
-        self.assertEqual(len(unpacked_files), 2)
+        assert meta_data['Intel Hex'] == 1
+        assert meta_data['Motorola S-Record'] == 1
+        assert f'{self.tmp_dir.name}/0x6.ihex' in unpacked_files
+        assert f'{self.tmp_dir.name}/0x291f.srec' in unpacked_files
+        assert len(unpacked_files) == 2
 
     def test_extraction_nothing_included(self):
         input_file = Path(TEST_DATA_DIR, 'nothing.bin')
         unpacked_files, _ = self.unpacker.extract_files_from_file(str(input_file), self.tmp_dir.name)
-        self.assertEqual(len(unpacked_files), 0)
+        assert len(unpacked_files) == 0

--- a/fact_extractor/plugins/unpacking/ros/test/test_ros.py
+++ b/fact_extractor/plugins/unpacking/ros/test/test_ros.py
@@ -18,9 +18,9 @@ class TestRosUnpacker(TestUnpackerBase):
     def test_extraction(self):
         in_file = os.path.join(TEST_DATA_DIR, 'test.ros')
         files, meta_data = self.unpacker.extract_files_from_file(in_file, self.tmp_dir.name)
-        self.assertEqual(len(files), 6, 'file number incorrect ({})'.format(files.__str__()))
-        self.assertIn('{}/DATETIME_C'.format(self.tmp_dir.name), files, 'Not all files found')
-        self.assertIn('file_information', meta_data, 'Output meta not set')
+        assert len(files) == 6, f'file number incorrect ({files})'
+        assert f'{self.tmp_dir.name}/DATETIME_C' in files, 'Not all files found'
+        assert 'file_information' in meta_data, 'Output meta not set'
 
 
 def test_infer_endianness():

--- a/fact_extractor/plugins/unpacking/stuffit/test/test_sit.py
+++ b/fact_extractor/plugins/unpacking/stuffit/test/test_sit.py
@@ -15,6 +15,6 @@ class TestSitUnpacker(TestUnpackerBase):
     def test_extraction(self):
         in_file = os.path.join(TEST_DATA_DIR, 'test.sitx')
         files, meta_data = self.unpacker.extract_files_from_file(in_file, self.tmp_dir.name)
-        self.assertEqual(len(files), 1, 'file number incorrect')
-        self.assertEqual(files, ['{}/Sampling SIM.app.rsrc'.format(self.tmp_dir.name)], 'not all files found')
-        self.assertIn('output', meta_data, 'output meta missing')
+        assert len(files) == 1, 'file number incorrect'
+        assert files == [f'{self.tmp_dir.name}/Sampling SIM.app.rsrc'], 'not all files found'
+        assert 'output' in meta_data, 'output meta missing'

--- a/fact_extractor/plugins/unpacking/tpl/test/test_tp_wr702n.py
+++ b/fact_extractor/plugins/unpacking/tpl/test/test_tp_wr702n.py
@@ -1,3 +1,5 @@
+# pylint: disable=attribute-defined-outside-init
+
 import os
 
 from common_helper_files import get_binary_from_file
@@ -10,13 +12,13 @@ TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 
 
 class TestTpWr702n(TestUnpackerBase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
 
         self.test_firmware = os.path.join(TEST_DATA_DIR, 'wr.fw')
         self.firmware_container = TPWR702N(self.test_firmware)
 
-    def tearDown(self):
+    def teardown_method(self):
         self.ds_tmp_dir.cleanup()
         self.tmp_dir.cleanup()
 
@@ -24,40 +26,48 @@ class TestTpWr702n(TestUnpackerBase):
         self.check_unpacker_selection('firmware/tp-wr702n', 'TP-WR702N')
 
     def test_get_meta_dict(self):
-        expected_meta_data = {'bootloader_offset': 26820,
-                              'img0': {'device_id': '0x0702',
-                                       'language': 'English',
-                                       'language_code': '0x1101',
-                                       'size': 1539104,
-                                       'sub_header': {'device_id': '0x0702',
-                                                      'language': 'English',
-                                                      'language_code': '0x1101',
-                                                      'size': 1276832}},
-                              'md5': 'a1ea03bf7466517aa545779640e01acd',
-                              'os_offset': 262420,
-                              'uncarved_area': [(0, 1539124)]}
+        expected_meta_data = {
+            'bootloader_offset': 26820,
+            'img0': {
+                'device_id': '0x0702',
+                'language': 'English',
+                'language_code': '0x1101',
+                'size': 1539104,
+                'sub_header': {
+                    'device_id': '0x0702',
+                    'language': 'English',
+                    'language_code': '0x1101',
+                    'size': 1276832,
+                },
+            },
+            'md5': 'a1ea03bf7466517aa545779640e01acd',
+            'os_offset': 262420,
+            'uncarved_area': [(0, 1539124)],
+        }
 
-        self.assertEqual(expected_meta_data, self.firmware_container.get_meta_dict())
+        assert expected_meta_data == self.firmware_container.get_meta_dict()
 
     def test_header_and_binary(self):
         self.unpacker.extract_files_from_file(self.test_firmware, self.tmp_dir.name)
-        expected_files_with_hash = {'container_header.hdr': '446d194c0e5beeccf9cd1534205cbeedcedf28491beaeb72d85e485f61071e0a',
-                                    'img0.hdr': '311c4a4f4c3c7b097c9419c58fe245bf2e2f7cedbaf3017870f34242a49b16b5',
-                                    'bootloader.7z': 'b4fa4a19502b82ea5984c8ee24396873e710c157adeafebd4bd3e51f40d5cf9f',
-                                    'main.img': '9af7e4f50e0220f8b38246b3f7d790b5078f6f049c2d35272ce5edb9a06464e9',
-                                    'main.7z': '099491872fcab8a4f05f18f1e3566150f3049bf1f3d9d6354437e5e371251e66',
-                                    'main.owfs': 'c14d965a60f1b388120695951fed05425e025af6f204332ea2eeca5b9427065d'}
+        expected_files_with_hash = {
+            'container_header.hdr': '446d194c0e5beeccf9cd1534205cbeedcedf28491beaeb72d85e485f61071e0a',
+            'img0.hdr': '311c4a4f4c3c7b097c9419c58fe245bf2e2f7cedbaf3017870f34242a49b16b5',
+            'bootloader.7z': 'b4fa4a19502b82ea5984c8ee24396873e710c157adeafebd4bd3e51f40d5cf9f',
+            'main.img': '9af7e4f50e0220f8b38246b3f7d790b5078f6f049c2d35272ce5edb9a06464e9',
+            'main.7z': '099491872fcab8a4f05f18f1e3566150f3049bf1f3d9d6354437e5e371251e66',
+            'main.owfs': 'c14d965a60f1b388120695951fed05425e025af6f204332ea2eeca5b9427065d',
+        }
 
-        for expected in expected_files_with_hash:
-            self._hash_compare(expected, expected_files_with_hash[expected])
+        for file, expected_hash in expected_files_with_hash.items():
+            self._hash_compare(file, expected_hash)
 
     def _hash_compare(self, filename, hashsum):
         binary_data = get_binary_from_file(os.path.join(self.tmp_dir.name, filename))
-        self.assertEqual(get_sha256(binary_data), hashsum, 'Checksum incorrect for file {}'.format(filename))
+        assert get_sha256(binary_data) == hashsum, f'Checksum incorrect for file {filename}'
 
     def test_extraction(self):
         in_file = self.test_firmware
-        files, meta_data = self.unpacker.extract_files_from_file(in_file, self.tmp_dir.name)
+        files, _ = self.unpacker.extract_files_from_file(in_file, self.tmp_dir.name)
 
         expected_container_header = 1
         expected_img0_header = 1
@@ -67,6 +77,13 @@ class TestTpWr702n(TestUnpackerBase):
         expected_fs = 1
         expected_remaining = 2
 
-        self.assertEqual(len(files),
-                         expected_remaining + expected_container_header + expected_bootloader + expected_main + expected_os + expected_fs + expected_img0_header,
-                         'file number incorrect')
+        assert (
+            len(files)
+            == expected_remaining
+            + expected_container_header
+            + expected_bootloader
+            + expected_main
+            + expected_os
+            + expected_fs
+            + expected_img0_header
+        ), 'file number incorrect'

--- a/fact_extractor/plugins/unpacking/tpl/test/test_tpl.py
+++ b/fact_extractor/plugins/unpacking/tpl/test/test_tpl.py
@@ -13,9 +13,9 @@ class TestTplTool(TestUnpackerBase):
 
     def test_extraction(self):
         files, meta_data = self.unpacker.extract_files_from_file(os.path.join(TEST_DATA_DIR, 'test.tpl'), self.tmp_dir.name)
-        self.assertEqual(len(files), 4)
+        assert len(files) == 4
         unpacked_files = [os.path.basename(f) for f in files]
         expected_files = ['test.tpl-rootfs', 'test.tpl-kernel', 'test.tpl-header', 'test.tpl-bootldr']
         for f in unpacked_files:
-            self.assertIn(f, expected_files)
-        self.assertIn('header-info', meta_data)
+            assert f in expected_files
+        assert 'header-info' in meta_data

--- a/fact_extractor/plugins/unpacking/trx/test/test_plugin_untrx.py
+++ b/fact_extractor/plugins/unpacking/trx/test/test_plugin_untrx.py
@@ -12,15 +12,16 @@ class TestUntrxUnpacker(TestUnpackerBase):
         self.check_unpacker_selection('firmware/trx', 'untrx')
 
     def test_extraction_trx(self):
-        files, meta_data = self.unpacker.extract_files_from_file(os.path.join(TEST_DATA_DIR, 'trx.img'), self.tmp_dir.name)
-        self.assertEqual(len(files), 1)
+        files, _ = self.unpacker.extract_files_from_file(os.path.join(TEST_DATA_DIR, 'trx.img'), self.tmp_dir.name)
+        assert len(files) == 1
         with zipfile.ZipFile(files[0], 'r') as extracted_file:
             included_file_list = [os.path.basename(f) for f in extracted_file.namelist() if os.path.basename(f)]
-            for f in ['test file 3_.txt', 'testfile1', 'testfile2']:
-                self.assertIn(f, included_file_list)
+            for file in ['test file 3_.txt', 'testfile1', 'testfile2']:
+                assert file in included_file_list
 
-        files, meta_data = self.unpacker.extract_files_from_file(os.path.join(TEST_DATA_DIR, 'netgear.trx'), self.tmp_dir.name)
-        self.assertEqual(len(files), 2)
+    def test_extraction_trx2(self):
+        files, _ = self.unpacker.extract_files_from_file(os.path.join(TEST_DATA_DIR, 'netgear.trx'), self.tmp_dir.name)
+        assert len(files) == 2
         included_file_list = [os.path.basename(f) for f in files if os.path.basename(f)]
-        for f in included_file_list:
-            self.assertIn(f, ['squashfs-lzma-image-x_x', 'segment1'])
+        for file in included_file_list:
+            assert file in ['squashfs-lzma-image-x_x', 'segment1']

--- a/fact_extractor/plugins/unpacking/ubi/test/test_plugin_ubi_image.py
+++ b/fact_extractor/plugins/unpacking/ubi/test/test_plugin_ubi_image.py
@@ -6,7 +6,7 @@ from test.unit.unpacker.test_unpacker import TestUnpackerBase
 TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 
 
-class Test_UBIFS_Unpacker(TestUnpackerBase):
+class TestUbiFsUnpacker(TestUnpackerBase):
 
     def test_unpacker_selection_generic(self):
         self.check_unpacker_selection('firmware/ubi-image', 'UBI-Image')
@@ -14,5 +14,5 @@ class Test_UBIFS_Unpacker(TestUnpackerBase):
     def test_extraction(self):
         test_file = os.path.join(TEST_DATA_DIR, 'ubi.img')
         files, meta_data = self.unpacker.extract_files_from_file(test_file, self.tmp_dir.name)
-        self.assertEqual(len(files), 1, 'file number incorrect')
-        self.assertEqual(meta_data['plugin_used'], 'UBI-Image', 'wrong plugin selected')
+        assert len(files) == 1, 'file number incorrect'
+        assert meta_data['plugin_used'] == 'UBI-Image', 'wrong plugin selected'

--- a/fact_extractor/plugins/unpacking/uboot/test/test_container_uboot_image.py
+++ b/fact_extractor/plugins/unpacking/uboot/test/test_container_uboot_image.py
@@ -1,31 +1,19 @@
-import unittest
-import os
+from pathlib import Path
 
 from ..internal.uboot_container import uBootHeader
 
+TEST_DATA_DIR = Path(__file__).parent / 'data'
 
-TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 
-
-class TestUbootImage(unittest.TestCase):
-
-    def setUp(self):
-        self.test_firmware = os.path.join(TEST_DATA_DIR, 'uboot.image_with_header')
-
+class TestUbootImage:
     def test_header(self):
-        expected_image_size = 32753
-        expected_arch = 5
-        expected_os = 5
-        expected_image_type = 5
-        expected_image_name = 'u-boot image'
-        expected_crc32 = 0x385a8513
-
         ubh = uBootHeader()
-        with open(self.test_firmware, 'r+b') as uboot_image:
+        test_firmware = TEST_DATA_DIR / 'uboot.image_with_header'
+        with test_firmware.open('r+b') as uboot_image:
             ubh.create_from_binary(uboot_image.read(64))
-        self.assertEqual(expected_image_size, ubh.image_data_size)
-        self.assertEqual(expected_arch, ubh.cpu_architecture)
-        self.assertEqual(expected_os, ubh.operating_system)
-        self.assertEqual(expected_image_type, ubh.image_type)
-        self.assertEqual(expected_image_name, ubh.image_name)
-        self.assertEqual(expected_crc32, ubh.image_data_crc)
+        assert ubh.image_data_size == 32753
+        assert ubh.cpu_architecture == 5
+        assert ubh.operating_system == 5
+        assert ubh.image_type == 5
+        assert ubh.image_name == 'u-boot image'
+        assert ubh.image_data_crc == 0x385A8513

--- a/fact_extractor/plugins/unpacking/uefi/test/test_plugin_uefi.py
+++ b/fact_extractor/plugins/unpacking/uefi/test/test_plugin_uefi.py
@@ -13,5 +13,5 @@ class TestUEFIUnpacker(TestUnpackerBase):
     def test_extraction(self):
         in_file = os.path.join(TEST_DATA_DIR, 'UEFI.CAP')
         files, meta_data = self.unpacker.extract_files_from_file(in_file, self.tmp_dir.name)
-        self.assertEqual(len(files), 1395, 'file number incorrect')
-        self.assertIn('output', meta_data)
+        assert len(files) == 1395, 'file number incorrect'
+        assert 'output' in meta_data

--- a/fact_extractor/plugins/unpacking/xerox/test/test_container_dsk_one.py
+++ b/fact_extractor/plugins/unpacking/xerox/test/test_container_dsk_one.py
@@ -23,7 +23,7 @@ class TestContainerDSKone:
     def test_error_handling_dsk(self):
         test_file = os.path.join(TEST_DATA_DIR, 'invalid_file')
         test_obj = DskOne(test_file)
-        assert len(test_obj.errors) >  0, 'errors should be present'
+        assert len(test_obj.errors) > 0, 'errors should be present'
 
         test_obj.header = b'inv'
         test_obj.HEADERSIZE = 0

--- a/fact_extractor/plugins/unpacking/xerox/test/test_container_dsk_one.py
+++ b/fact_extractor/plugins/unpacking/xerox/test/test_container_dsk_one.py
@@ -1,30 +1,29 @@
 import os
 import gc
-import unittest
 
 from helperFunctions.hash import get_sha256
 
 from ..internal.dsk_container import DskOne
 from plugins.unpacking.xerox.internal.dsk_container import ExtendedDskOne
 
-
 TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 
 
-class TestContainerDSKone(unittest.TestCase):
-
+class TestContainerDSKone:
     def test_init_dsk(self):
         test_file = os.path.join(TEST_DATA_DIR, 'test.dsk1')
         test_obj = DskOne(test_file)
-        self.assertEqual(test_obj.raw[1:4], b'DSK', 'Raw Data not set correct')
-        self.assertEqual(test_obj.header[1], b'DSK1.0', 'header parsing not correct')
-        self.assertEqual(test_obj.payload_size, 860293, 'payload length not correct')
-        self.assertEqual(get_sha256(test_obj.decoded_payload), '057e936e6c1d45d617fe52decd532776c95c06a1b5e4a8f752d4227a645e5edc', 'payload checksum not correct')
+        assert test_obj.raw[1:4] == b'DSK', 'Raw Data not set correct'
+        assert test_obj.header[1] == b'DSK1.0', 'header parsing not correct'
+        assert test_obj.payload_size == 860293, 'payload length not correct'
+        assert (
+            get_sha256(test_obj.decoded_payload) == '057e936e6c1d45d617fe52decd532776c95c06a1b5e4a8f752d4227a645e5edc'
+        ), 'payload checksum not correct'
 
     def test_error_handling_dsk(self):
         test_file = os.path.join(TEST_DATA_DIR, 'invalid_file')
         test_obj = DskOne(test_file)
-        self.assertGreater(len(test_obj.errors), 0, 'errors should be present')
+        assert len(test_obj.errors) >  0, 'errors should be present'
 
         test_obj.header = b'inv'
         test_obj.HEADERSIZE = 0
@@ -33,17 +32,17 @@ class TestContainerDSKone(unittest.TestCase):
         meta = test_obj.get_meta_dict()
         test_obj.log_errors_and_warnings()
 
-        self.assertIn('unpack errors', meta, 'errors missing in dict')
-        self.assertIn('unpack warnings', meta, 'warnings missing in dict')
+        assert 'unpack errors' in meta, 'errors missing in dict'
+        assert 'unpack warnings' in meta, 'warnings missing in dict'
 
         test_obj.payload_size = 1000
         test_obj.check_validity()
-        self.assertIn(test_obj.errors[-1], 'payload length longer than file: 1000 -> 7')
+        assert test_obj.errors[-1] in 'payload length longer than file: 1000 -> 7'
 
     def test_error_handling_dsk_ext(self):
         test_file = os.path.join(TEST_DATA_DIR, 'invalid_file')
         test_obj = ExtendedDskOne(test_file)
-        self.assertIn('Extended DSK error', test_obj.meta, 'errors missing')
+        assert 'Extended DSK error' in test_obj.meta, 'errors missing'
 
-    def tearDown(self):
+    def teardown_method(self):
         gc.collect()

--- a/fact_extractor/plugins/unpacking/xerox/test/test_dlm.py
+++ b/fact_extractor/plugins/unpacking/xerox/test/test_dlm.py
@@ -1,3 +1,5 @@
+# pylint: disable=attribute-defined-outside-init
+
 from pathlib import Path
 
 from common_helper_files import get_binary_from_file
@@ -10,8 +12,8 @@ TEST_DATA_DIR = Path(Path(__file__).parent, 'data')
 
 
 class TestXeroxDLM(TestUnpackerBase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
 
         self.test_path = str(Path(TEST_DATA_DIR, 'DLM-First_1MB.DLM'))
         self.firmware_container = XeroxDLM(self.test_path)
@@ -21,30 +23,34 @@ class TestXeroxDLM(TestUnpackerBase):
 
     def test_get_header_end_offset(self):
         expected_offset = 0x243
-        self.assertEqual(expected_offset, self.firmware_container.get_header_end_offset())
+        assert expected_offset == self.firmware_container.get_header_end_offset()
 
     def test_get_signature(self):
         expected_signature = '90ec11f7b52468378362987a4ed9e56855070915887e6afe567e1c47875b29f9'
-        self.assertEqual(expected_signature, self.firmware_container.get_signature())
+        assert expected_signature == self.firmware_container.get_signature()
 
     def test_get_dlm_version(self):
         expected = 'NO_DLM_VERSION_CHECK'
-        self.assertEqual(expected, self.firmware_container.get_dlm_version())
+        assert expected == self.firmware_container.get_dlm_version()
 
     def test_get_dlm_name(self):
         expected = '080415_08142013'
-        self.assertEqual(expected, self.firmware_container.get_dlm_name())
+        assert expected == self.firmware_container.get_dlm_name()
 
     def test_header_and_binary(self):
         files, meta_data = self.unpacker.extract_files_from_file(self.test_path, self.tmp_dir.name)
         files = set(files)
-        self.assertEqual(len(files), 1, 'file number incorrect')
+        assert len(files) == 1, 'file number incorrect'
         data_bin = get_binary_from_file(str(Path(self.tmp_dir.name, 'dlm_data.bin')))
-        self.assertEqual(get_sha256(data_bin), '701962b0d11f50d9129d5a1655ee054865e90cd1b547d40d590ea96f7dfb64eb')
-        self.assertEqual(meta_data['dlm_version'], 'NO_DLM_VERSION_CHECK', 'meta: dlm_version not correct')
-        self.assertEqual(meta_data['dlm_signature'], '90ec11f7b52468378362987a4ed9e56855070915887e6afe567e1c47875b29f9', 'meta: dlm_signature not correct')
-        self.assertEqual(meta_data['dlm_name'], '080415_08142013', 'meta: dlm_name not correct')
-        self.assertEqual(meta_data['dlm_extraction_criteria'], 'upgradeExtract.sh /tmp/080415_08142013.dnld', 'meta: dlm_criteria not correct')
+        assert get_sha256(data_bin) == '701962b0d11f50d9129d5a1655ee054865e90cd1b547d40d590ea96f7dfb64eb'
+        assert meta_data['dlm_version'] == 'NO_DLM_VERSION_CHECK', 'meta: dlm_version not correct'
+        assert (
+            meta_data['dlm_signature'] == '90ec11f7b52468378362987a4ed9e56855070915887e6afe567e1c47875b29f9'
+        ), 'meta: dlm_signature not correct'
+        assert meta_data['dlm_name'] == '080415_08142013', 'meta: dlm_name not correct'
+        assert (
+            meta_data['dlm_extraction_criteria'] == 'upgradeExtract.sh /tmp/080415_08142013.dnld'
+        ), 'meta: dlm_criteria not correct'
 
     def test_str(self):
-        self.assertEqual(self.firmware_container.__str__()[0:3], 'DLM')
+        assert str(self.firmware_container)[0:3] == 'DLM'

--- a/fact_extractor/plugins/unpacking/xerox/test/test_dsk.py
+++ b/fact_extractor/plugins/unpacking/xerox/test/test_dsk.py
@@ -15,6 +15,6 @@ class TestUnpackerPluginDsk(TestUnpackerBase):
     def test_extraction(self):
         test_file = os.path.join(TEST_DATA_DIR, 'test.dsk1')
         files, meta_data = self.unpacker.extract_files_from_file(test_file, self.tmp_dir.name)
-        self.assertEqual(len(files), 1, 'Number of extracted files not correct')
-        self.assertEqual(meta_data['payload size'], 860293, 'meta data not set correctly')
-        self.assertEqual(meta_data['encoding_overhead'], 0.33, 'encoding overhead not correct')
+        assert len(files) == 1, 'Number of extracted files not correct'
+        assert meta_data['payload size'] == 860293, 'meta data not set correctly'
+        assert meta_data['encoding_overhead'] == 0.33, 'encoding overhead not correct'

--- a/fact_extractor/plugins/unpacking/xerox/test/test_dsk_extended.py
+++ b/fact_extractor/plugins/unpacking/xerox/test/test_dsk_extended.py
@@ -15,6 +15,6 @@ class TestUnpackerPluginDsk(TestUnpackerBase):
     def test_extraction(self):
         test_file = os.path.join(TEST_DATA_DIR, 'test.dsk_ext')
         files, meta_data = self.unpacker.extract_files_from_file(test_file, self.tmp_dir.name)
-        self.assertEqual(len(files), 1, 'Number of extracted files not correct')
-        self.assertEqual(meta_data['payload size'], 151256, 'meta data not set correctly')
-        self.assertEqual(meta_data['encoding_overhead'], 0.33, 'encoding overhead not correct')
+        assert len(files) == 1, 'Number of extracted files not correct'
+        assert meta_data['payload size'] == 151256, 'meta data not set correctly'
+        assert meta_data['encoding_overhead'] == 0.33, 'encoding overhead not correct'

--- a/fact_extractor/plugins/unpacking/xerox/test/test_postscript.py
+++ b/fact_extractor/plugins/unpacking/xerox/test/test_postscript.py
@@ -19,23 +19,23 @@ class TestUnpackerPluginPostscript(TestUnpackerBase):
 
     def test_extraction(self):
         files, meta_data = self.unpacker.extract_files_from_file(TEST_FILE, self.tmp_dir.name)
-        self.assertEqual(meta_data['plugin_used'], 'Postscript', 'wrong plugin selected')
-        self.assertEqual(meta_data['Title'], 'Firmware Update', 'meta data not set correctly')
-        self.assertEqual(meta_data['ReleaseVersions'], 'vx=10.80,ps=4.19.0,net=44.38,eng=26.P.1.4.19.0')
-        self.assertEqual(meta_data['encoding_overhead'], 0.25, 'encoding overhead not correct')
-        self.assertEqual(len(meta_data.keys()), 11, 'number of found meta data not correct')
-        self.assertEqual(len(files), 3, 'Number of extracted files not correct')
+        assert meta_data['plugin_used'] == 'Postscript', 'wrong plugin selected'
+        assert meta_data['Title'] == 'Firmware Update', 'meta data not set correctly'
+        assert meta_data['ReleaseVersions'] == 'vx=10.80,ps=4.19.0,net=44.38,eng=26.P.1.4.19.0'
+        assert meta_data['encoding_overhead'] == 0.25, 'encoding overhead not correct'
+        assert len(meta_data.keys()) == 11, 'number of found meta data not correct'
+        assert len(files) == 3, 'Number of extracted files not correct'
 
     def test_convert_payloads(self):
         raw_payloads = [b'<~FCfN8~>', b'<~FCfN8?YjFoAR\nAneART?~>']
         result = _convert_payloads(raw_payloads)
-        self.assertEqual(result[0], b'test', 'simple payload not correct')
-        self.assertEqual(result[1], b'test_line_break', 'line breaked payload not correct')
+        assert result[0] == b'test', 'simple payload not correct'
+        assert result[1] == b'test_line_break', 'line breaked payload not correct'
 
     def test_get_raw_payloads(self):
         raw_content = get_binary_from_file(TEST_FILE)
         payloads = _get_raw_payloads(raw_content)
-        self.assertEqual(len(payloads), 3, "number of payloads not correct")
-        self.assertEqual(payloads[0], b'<~<+oue+DGm>FD,5.Anc:,F<FCgH#.D-A0C~>', "simple payload not correct")
-        self.assertEqual(payloads[1], b'<~<+oue+DGm>@3BW&@rH6q+Dl72BHV,0DJ*O$+E1b7Ci<`m+EV:*F<GX<Dfol,+Cf>-FCAm$+\nEM+;ATD3q+Dbb0ATJu&DIal2D]it9/hSa~>', "multiline payload not correct")
-        self.assertEqual(payloads[2], b'<~@;^"*BOu3kAoD^,@<;~>', "other header format")
+        assert len(payloads) == 3, "number of payloads not correct"
+        assert payloads[0] == b'<~<+oue+DGm>FD,5.Anc:,F<FCgH#.D-A0C~>', "simple payload not correct"
+        assert payloads[1] == b'<~<+oue+DGm>@3BW&@rH6q+Dl72BHV,0DJ*O$+E1b7Ci<`m+EV:*F<GX<Dfol,+Cf>-FCAm$+\nEM+;ATD3q+Dbb0ATJu&DIal2D]it9/hSa~>', "multiline payload not correct"
+        assert payloads[2] == b'<~@;^"*BOu3kAoD^,@<;~>', "other header format"

--- a/fact_extractor/plugins/unpacking/zlib/test/test_plugin_zlib.py
+++ b/fact_extractor/plugins/unpacking/zlib/test/test_plugin_zlib.py
@@ -16,9 +16,9 @@ class TestUnpackerPluginZlib(TestUnpackerBase):
     def test_extraction(self):
         in_file = os.path.join(TEST_DATA_DIR, 'test.zlib')
         files, meta_data = self.unpacker.extract_files_from_file(in_file, self.tmp_dir.name)
-        self.assertEqual(len(files), 1, 'number of extracted files not correct')
-        self.assertEqual(files[0], os.path.join(self.tmp_dir.name, 'zlib_decompressed'), 'file name not correct')
+        assert len(files) == 1, 'number of extracted files not correct'
+        assert files[0] == os.path.join(self.tmp_dir.name, 'zlib_decompressed'), 'file name not correct'
         file_binary = get_binary_from_file(files[0])
         file_hash = get_sha256(file_binary)
-        self.assertEqual(file_hash, 'e429103649e24ca126077bfb38cce8c57cc913a966d7e36356e4fe0513ab02c4')
-        self.assertEqual(len(meta_data.keys()), 4, 'more or fewer than standard keys in meta dict')
+        assert file_hash == 'e429103649e24ca126077bfb38cce8c57cc913a966d7e36356e4fe0513ab02c4'
+        assert len(meta_data.keys()) == 4, 'more or fewer than standard keys in meta dict'

--- a/fact_extractor/test/unit/helperFunctions/test_file_system.py
+++ b/fact_extractor/test/unit/helperFunctions/test_file_system.py
@@ -1,47 +1,50 @@
 import os
-import unittest
+from pathlib import Path
 
+import pytest
 from common_helper_files import get_files_in_dir
 from helperFunctions.file_system import (
-    file_is_empty, get_fact_bin_dir, get_src_dir, get_test_data_dir, file_name_sanitize
+    file_is_empty,
+    get_fact_bin_dir,
+    get_src_dir,
+    get_test_data_dir,
+    file_name_sanitize,
 )
 
 
-class TestFileSystemHelpers(unittest.TestCase):
+class TestFileSystemHelpers:
+    def setup_method(self):
+        self.current_cwd = os.getcwd()  # pylint: disable=attribute-defined-outside-init
 
-    def setUp(self):
-        self.current_cwd = os.getcwd()
-
-    def tearDown(self):
+    def teardown_method(self):
         os.chdir(self.current_cwd)
 
-    def check_correct_src_dir(self, working_directory):
+    @pytest.mark.parametrize('working_directory', [os.getcwd(), '/'])
+    def test_check_correct_src_dir(self, working_directory):
         real_src_dir = get_src_dir()
-        os.chdir(working_directory)
-        self.assertTrue(os.path.exists('{}/helperFunctions/file_system.py'.format(real_src_dir)), 'file_system.py found in correct place')
-        self.assertEqual(get_src_dir(), real_src_dir, 'same source dir before and after chdir')
-
-    def test_get_src_dir_cwd(self):
-        self.check_correct_src_dir(os.getcwd())
-
-    def test_get_src_dir_root(self):
-        self.check_correct_src_dir('/')
+        cwd = os.getcwd()
+        try:
+            os.chdir(working_directory)
+            assert Path(f'{real_src_dir}/helperFunctions/file_system.py').is_file()
+            assert get_src_dir() == real_src_dir, 'same source dir before and after chdir'
+        finally:
+            os.chdir(cwd)
 
     def test_get_fact_bin_dir(self):
         bin_dir = get_fact_bin_dir()
         files_in_bin_dir = [os.path.basename(f) for f in get_files_in_dir(bin_dir)]
-        self.assertTrue(os.path.isdir(bin_dir))
-        self.assertIn('fact_extractor/bin', bin_dir)
-        self.assertIn('untrx', files_in_bin_dir)
+        assert os.path.isdir(bin_dir)
+        assert 'fact_extractor/bin' in bin_dir
+        assert 'untrx' in files_in_bin_dir
 
     def test_file_is_zero(self):
-        self.assertTrue(file_is_empty('{}/zero_byte'.format(get_test_data_dir())), 'file is empty but stated differently')
-        self.assertFalse(file_is_empty('{}/get_files_test/testfile1'.format(get_test_data_dir())), 'file not empty but stated differently')
-        self.assertFalse(file_is_empty(os.path.join(get_test_data_dir(), 'broken_link')), 'Broken link is not empty')
+        assert file_is_empty(f'{get_test_data_dir()}/zero_byte'), 'file is empty'
+        assert not file_is_empty(f'{get_test_data_dir()}/get_files_test/testfile1'), 'file is not empty'
+        assert not file_is_empty(os.path.join(get_test_data_dir(), 'broken_link')), 'Broken link is not empty'
 
     def test_sanitize_file_name(self):
-        self.assertEqual(file_name_sanitize('../../../../a/b/c/d'), 'a/b/c/d', 'file was not sanitized')
-        self.assertEqual(file_name_sanitize('dir/../../../../a/b/c/d'), 'dir/a/b/c/d', 'file was not sanitized')
+        assert file_name_sanitize('../../../../a/b/c/d') == 'a/b/c/d', 'file was not sanitized'
+        assert file_name_sanitize('dir/../../../../a/b/c/d') == 'dir/a/b/c/d', 'file was not sanitized'
 
     def test_file_is_zero_broken_link(self):
-        self.assertFalse(file_is_empty(os.path.join(get_test_data_dir(), 'broken_link')), 'Broken link is not empty')
+        assert not file_is_empty(os.path.join(get_test_data_dir(), 'broken_link')), 'Broken link is not empty'

--- a/fact_extractor/test/unit/helperFunctions/test_hash.py
+++ b/fact_extractor/test/unit/helperFunctions/test_hash.py
@@ -3,14 +3,12 @@ Created on 21.08.2015
 
 @author: weidenba
 '''
-import unittest
-
 from helperFunctions.hash import get_sha256
 
 
-class Test_hash_generation(unittest.TestCase):
-    test_string = "test string"
-    test_string_SHA256 = "d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b"
+class TestHashGeneration:
+    test_string = 'test string'
+    test_string_SHA256 = 'd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
 
     def test_get_sha256(self):
-        self.assertEqual(get_sha256(self.test_string), self.test_string_SHA256, "not correct from string")
+        assert get_sha256(self.test_string) == self.test_string_SHA256, 'not correct from string'

--- a/fact_extractor/test/unit/helperFunctions/test_plugin.py
+++ b/fact_extractor/test/unit/helperFunctions/test_plugin.py
@@ -1,19 +1,18 @@
-import unittest
 from helperFunctions.plugin import _get_plugin_src_dirs, import_plugins
 
 TEST_PLUGINS_BASE_PATH = 'test/data/plugin_system'
 
 
-class TestHelperFunctionsPlugin(unittest.TestCase):
+class TestHelperFunctionsPlugin:
 
     def test_get_plugin_src_dirs(self):
         result = _get_plugin_src_dirs(TEST_PLUGINS_BASE_PATH)
-        self.assertIsInstance(result, list, 'result is not a list')
-        self.assertIn('plugin_one', sorted(result)[0], 'plugin not found')
-        self.assertEqual(len(result), 2, 'number of found plugin directories not correct')
+        assert isinstance(result, list), 'result is not a list'
+        assert 'plugin_one' in sorted(result)[0], 'plugin not found'
+        assert len(result) == 2, 'number of found plugin directories not correct'
 
     def test_load_plugins(self):
         result = import_plugins('plugins.test', TEST_PLUGINS_BASE_PATH)
         imported_plugins = result.list_plugins()
-        self.assertEqual(len(imported_plugins), 1, 'worng number of plugins imported')
-        self.assertEqual(imported_plugins[0], 'plugin_one', 'plugin name not correct')
+        assert len(imported_plugins) == 1, 'wrong number of plugins imported'
+        assert imported_plugins[0] == 'plugin_one', 'plugin name not correct'

--- a/fact_extractor/test/unit/unpacker/test_carved_area.py
+++ b/fact_extractor/test/unit/unpacker/test_carved_area.py
@@ -1,12 +1,11 @@
 import gc
-import unittest
 
 from unpacker.helper.carving import CarvedArea
 
 
-class TestCarvedArea(unittest.TestCase):
+class TestCarvedArea:
 
-    def tearDown(self):
+    def teardown_method(self):
         gc.collect()
 
     def test_carved_complete_area(self):
@@ -45,16 +44,16 @@ class TestCarvedArea(unittest.TestCase):
         carved_area.carved((1180160, 8258048))
 
         expected = [(513, 15439), (48258, 131583), (1066831, 1180159)]
-        self.assertEqual(len(expected), len(carved_area.non_carved_areas))
+        assert len(carved_area.non_carved_areas) == len(expected)
 
         for area in expected:
-            self.assertIn(area, carved_area.non_carved_areas)
+            assert area in carved_area.non_carved_areas
 
-        self.assertEqual('(513:15439) (48258:131583) (1066831:1180159) ', str(carved_area))
+        assert str(carved_area) == '(513:15439) (48258:131583) (1066831:1180159) '
 
     def caring_test(self, area_size, carved_and_expected):
         for test_data in carved_and_expected:
             carved_area = CarvedArea(area_size)
             carved_area.carved(test_data['carved'])
 
-            self.assertEqual(test_data['expected'], carved_area.non_carved_areas, test_data)
+            assert test_data['expected'] == carved_area.non_carved_areas, test_data

--- a/fact_extractor/test/unit/unpacker/test_unpacker.py
+++ b/fact_extractor/test/unit/unpacker/test_unpacker.py
@@ -1,10 +1,11 @@
+# pylint: disable=attribute-defined-outside-init
+
 from __future__ import annotations
 
 import gc
 import json
 import os
 import shutil
-import unittest
 from configparser import ConfigParser
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -14,8 +15,8 @@ from helperFunctions.file_system import get_test_data_dir
 from unpacker.unpack import Unpacker
 
 
-class TestUnpackerBase(unittest.TestCase):
-    def setUp(self):
+class TestUnpackerBase:
+    def setup_method(self):
         self.config = ConfigParser()
         self.ds_tmp_dir = TemporaryDirectory(prefix='fact_tests_')
         self.tmp_dir = TemporaryDirectory(prefix='fact_tests_')
@@ -33,19 +34,19 @@ class TestUnpackerBase(unittest.TestCase):
 
         self.test_file_path = Path(get_test_data_dir(), 'get_files_test/testfile1')
 
-    def tearDown(self):
+    def teardown_method(self):
         self.ds_tmp_dir.cleanup()
         self.tmp_dir.cleanup()
         gc.collect()
 
     def get_unpacker_meta(self):
         return json.loads(
-            Path(self.unpacker._report_folder, 'meta.json').read_text()
-        )  # pylint: disable=protected-access
+            Path(self.unpacker._report_folder, 'meta.json').read_text()  # pylint: disable=protected-access
+        )
 
     def check_unpacker_selection(self, mime_type, plugin_name):
         name = self.unpacker.get_unpacker(mime_type)[1]
-        self.assertEqual(name, plugin_name, 'wrong unpacker plugin selected')
+        assert name == plugin_name, 'wrong unpacker plugin selected'
 
     def check_unpacking_of_standard_unpack_set(
         self,
@@ -56,12 +57,12 @@ class TestUnpackerBase(unittest.TestCase):
     ):
         files, meta_data = self.unpacker.extract_files_from_file(str(in_file), self.tmp_dir.name)
         files = {f for f in files if not any(rule in f for rule in ignore or set())}
-        assert len(files) == 3, 'file number incorrect'
+        assert len(files) == 3, f'file number incorrect: {meta_data}'
         assert files == {
             os.path.join(self.tmp_dir.name, additional_prefix_folder, 'testfile1'),
             os.path.join(self.tmp_dir.name, additional_prefix_folder, 'testfile2'),
             os.path.join(self.tmp_dir.name, additional_prefix_folder, 'generic folder/test file 3_.txt'),
-        }, 'not all files found'
+        }, f'not all files found: {meta_data}'
         if output:
             assert 'output' in meta_data
         return meta_data
@@ -69,11 +70,9 @@ class TestUnpackerBase(unittest.TestCase):
 
 class TestUnpackerCore(TestUnpackerBase):
     def test_generic_carver_found(self):
-        self.assertTrue(
-            'generic/carver' in list(self.unpacker.unpacker_plugins.keys()), 'generic carver plugin not found'
-        )
+        assert 'generic/carver' in list(self.unpacker.unpacker_plugins), 'generic carver plugin not found'
         name = self.unpacker.unpacker_plugins['generic/carver'][1]
-        self.assertEqual(name, 'generic_carver', 'generic_carver plugin not found')
+        assert name == 'generic_carver', 'generic_carver plugin not found'
 
     def test_unpacker_selection_unknown(self):
         self.check_unpacker_selection('unknown/blah', 'generic_carver')
@@ -87,9 +86,9 @@ class TestUnpackerCore(TestUnpackerBase):
         file_paths = [f'{get_test_data_dir()}/zero_byte', f'{get_test_data_dir()}/get_files_test/testfile1']
         moved_files = self.unpacker.move_extracted_files(file_paths, get_test_data_dir())
 
-        self.assertEqual(len(moved_files), 1, 'number of objects not correct')
-        self.assertEqual(moved_files[0].name, 'testfile1', 'wrong object created')
-        self.assertIn('/get_files_test/testfile1', str(moved_files[0].absolute()))
+        assert len(moved_files) == 1, 'number of objects not correct'
+        assert moved_files[0].name == 'testfile1', 'wrong object created'
+        assert '/get_files_test/testfile1' in str(moved_files[0].absolute())
 
     @patch('unpacker.unpack.shutil.move', shutil.copy2)
     def test_extract_everything(self):
@@ -98,17 +97,17 @@ class TestUnpackerCore(TestUnpackerBase):
         moved_files = self.unpacker.move_extracted_files(file_paths, get_test_data_dir())
         moved_files.sort()
 
-        self.assertEqual(len(moved_files), 2, 'number of objects not correct')
-        self.assertEqual(moved_files[1].name, 'zero_byte', 'empty files should not be discarded')
+        assert len(moved_files) == 2, 'number of objects not correct'
+        assert moved_files[1].name == 'zero_byte', 'empty files should not be discarded'
 
     @patch('unpacker.unpack.shutil.move')
-    def test_move_extracted_files(self, mock_shutil):
+    def test_move_extracted_files(self, mock_shutil):  # pylint: disable=unused-argument
         file_paths = [f'{get_test_data_dir()}/fake_file', f'{get_test_data_dir()}/get_files_test/testfile1']
         moved_files = self.unpacker.move_extracted_files(file_paths, get_test_data_dir())
 
-        self.assertEqual(len(moved_files), 2, 'number of objects not correct')
-        self.assertEqual(moved_files[1].name, 'testfile1', 'wrong object created')
-        self.assertIn('/get_files_test/testfile1', str(moved_files[1].absolute()))
+        assert len(moved_files) == 2, 'number of objects not correct'
+        assert moved_files[1].name == 'testfile1', 'wrong object created'
+        assert '/get_files_test/testfile1' in str(moved_files[1].absolute())
 
     @patch('unpacker.unpack.shutil.move')
     def test_move_extracted_files_raise_assert(self, mock_shutil):
@@ -118,9 +117,9 @@ class TestUnpackerCore(TestUnpackerBase):
 
         moved_files = self.unpacker.move_extracted_files(file_paths, get_test_data_dir())
 
-        self.assertEqual(len(moved_files), 1, 'number of objects not correct')
-        self.assertEqual(moved_files[0].name, 'testfile1', 'wrong object created')
-        self.assertIn('/get_files_test/testfile1', str(moved_files[0].absolute()))
+        assert len(moved_files) == 1, 'number of objects not correct'
+        assert moved_files[0].name == 'testfile1', 'wrong object created'
+        assert '/get_files_test/testfile1' in str(moved_files[0].absolute())
 
     def test_clean_up(self):
         temp_dir = Mock()
@@ -137,17 +136,17 @@ class TestUnpackerCore(TestUnpackerBase):
     def test_unpack_failure_generic_fs_fallback(self):
         self.unpacker.FS_FALLBACK_CANDIDATES = ['7z']
         meta_data = self._unpack_fallback_check('generic/fs', 'generic_carver')
-        self.assertIn('0_FALLBACK_genericFS', meta_data, 'generic FS Fallback entry missing')
-        self.assertIn('0_ERROR_genericFS', meta_data, 'generic FS ERROR entry missing')
+        assert '0_FALLBACK_genericFS' in meta_data, 'generic FS Fallback entry missing'
+        assert '0_ERROR_genericFS' in meta_data, 'generic FS ERROR entry missing'
 
     def _unpack_fallback_check(self, fallback_mime, fallback_plugin_name):
         broken_zip = Path(get_test_data_dir(), 'container/broken.zip')
         self.unpacker.unpack(broken_zip)
         meta_data = self.get_unpacker_meta()
 
-        self.assertEqual(meta_data['0_ERROR_7z'][0:6], '\n7-Zip')
-        self.assertEqual(meta_data['0_FALLBACK_7z'], f'7z (failed) -> {fallback_mime} (fallback)')
-        self.assertEqual(meta_data['plugin_used'], fallback_plugin_name)
+        assert meta_data['0_ERROR_7z'][0:6] == '\n7-Zip'
+        assert meta_data['0_FALLBACK_7z'] == f'7z (failed) -> {fallback_mime} (fallback)'
+        assert meta_data['plugin_used'] == fallback_plugin_name
 
         return meta_data
 
@@ -157,14 +156,12 @@ class TestUnpackerCoreMain(TestUnpackerBase):
         extracted_files = self.unpacker.unpack(file_path)
         meta_data = self.get_unpacker_meta()
 
-        self.assertEqual(len(extracted_files), number_unpacked_files, 'not all files found')
-        self.assertEqual(meta_data['plugin_used'], first_unpacker, 'Wrong plugin in Meta')
-        self.assertEqual(
-            meta_data['number_of_unpacked_files'], number_unpacked_files, 'Number of unpacked files wrong in Meta'
-        )
-        self.assertEqual(
-            meta_data['number_of_excluded_files'], number_of_excluded_files, 'Number of excluded files wrong in Meta'
-        )
+        assert len(extracted_files) == number_unpacked_files, 'not all files found'
+        assert meta_data['plugin_used'] == first_unpacker, 'Wrong plugin in Meta'
+        assert meta_data['number_of_unpacked_files'] == number_unpacked_files, 'Number of unpacked files wrong in Meta'
+        assert (
+            meta_data['number_of_excluded_files'] == number_of_excluded_files
+        ), 'Number of excluded files wrong in Meta'
 
     def test_main_unpack_function(self):
         test_file_path = Path(get_test_data_dir(), 'container/test.zip')


### PR DESCRIPTION
- fixed pytest 8 deprecation warnings
- enabled use of `pytest.mark.parametrize`, etc.
- fixed some pylint issues