### PR TITLE
patool installation update

### DIFF
--- a/fact_extractor/install/unpacker.py
+++ b/fact_extractor/install/unpacker.py
@@ -155,7 +155,7 @@ DEPENDENCIES = {
             'git+https://github.com/armbues/python-entropy',  # To be checked. Original dependency was deleted.
             'git+https://github.com/fkie-cad/common_helper_unpacking_classifier.git',
             'git+https://github.com/fkie-cad/fact_helper_file.git',
-            'patool',
+            'git+https://github.com/wummel/patool.git',
             'archmage',
             # jefferson + deps
             'git+https://github.com/sviehb/jefferson.git',


### PR DESCRIPTION
patool installation: switched from PyPI to GitHub repo because the release version wasn't updated for like 7 years