### PR TITLE
sasquatch lzma bugfix

### DIFF
--- a/fact_extractor/plugins/unpacking/squashFS/code/squash_fs.py
+++ b/fact_extractor/plugins/unpacking/squashFS/code/squash_fs.py
@@ -7,17 +7,20 @@ from pathlib import Path
 
 from helperFunctions.file_system import get_fact_bin_dir
 
-
 SASQUATCH = Path('/usr/local/bin/sasquatch')
 UNSQUASHFS4_AVM_BE = Path(get_fact_bin_dir()) / 'unsquashfs4-avm-be'
 UNSQUASHFS4_AVM_LE = Path(get_fact_bin_dir()) / 'unsquashfs4-avm-le'
 UNSQUASHFS3_MULTI = Path(get_fact_bin_dir()) / 'unsquashfs3-multi'
 
-
 NAME = 'SquashFS'
 MIME_PATTERNS = ['filesystem/squashfs']
-VERSION = '0.9'
-SQUASH_UNPACKER = [SASQUATCH, UNSQUASHFS4_AVM_BE, UNSQUASHFS4_AVM_LE, UNSQUASHFS3_MULTI]
+VERSION = '0.10'
+SQUASH_UNPACKER = [
+    (SASQUATCH, '-c lzma-adaptive'),
+    (UNSQUASHFS4_AVM_BE, '-scan'),
+    (UNSQUASHFS4_AVM_LE, '-scan'),
+    (UNSQUASHFS3_MULTI, '-scan'),
+]
 
 
 def unpack_function(file_path, tmp_dir):
@@ -25,10 +28,9 @@ def unpack_function(file_path, tmp_dir):
     file_path specifies the input file.
     tmp_dir should be used to store the extracted files.
     '''
-    unpack_result = dict()
-    for unpacker in SQUASH_UNPACKER:
-        scan_parameter = '-scan' if '-avm-' in unpacker.name else ''
-        output = execute_shell_command(f'fakeroot {unpacker} {scan_parameter} -d {tmp_dir}/fact_extracted {file_path}')
+    unpack_result = {}
+    for unpacker, parameter in SQUASH_UNPACKER:
+        output = execute_shell_command(f'fakeroot {unpacker} {parameter} -d {tmp_dir}/fact_extracted {file_path}')
         if _unpack_success(tmp_dir):
             unpack_result['unpacking_tool'] = unpacker.name
             unpack_result['output'] = output

--- a/fact_extractor/plugins/unpacking/squashFS/test/test_plugin_squashfs.py
+++ b/fact_extractor/plugins/unpacking/squashFS/test/test_plugin_squashfs.py
@@ -6,28 +6,30 @@ from test.unit.unpacker.test_unpacker import TestUnpackerBase
 
 from ..code.squash_fs import _unpack_success, unpack_function, SQUASH_UNPACKER
 
-
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.parametrize('unpack_path, expected', [
-    ('/foo/bar/unpacker', False),
-    (TEST_DATA_DIR, True),
-])
+@pytest.mark.parametrize(
+    'unpack_path, expected',
+    [
+        ('/foo/bar/unpacker', False),
+        (TEST_DATA_DIR, True),
+    ],
+)
 def test_unpack_success(unpack_path, expected):
     assert _unpack_success(unpack_path) == expected
 
 
 def test_not_unpackable_file():
     empty_test_file = TEST_DATA_DIR / 'empty'
-    unpack_dir = TemporaryDirectory(prefix='fact_test_')
-    result = unpack_function(empty_test_file, unpack_dir)
-    assert 'sasquatch - error' in result.keys()
-    assert 'unsquashfs4-avm-be - error' in result.keys()
+    with TemporaryDirectory(prefix='fact_test_') as unpack_dir:
+        result = unpack_function(empty_test_file, unpack_dir)
+    assert 'sasquatch - error' in result
+    assert 'unsquashfs4-avm-be - error' in result
 
 
-def test_tool_pathes_set_correctly():
-    for unpacker in SQUASH_UNPACKER:
+def test_tool_paths_set_correctly():
+    for unpacker, _ in SQUASH_UNPACKER:
         assert unpacker.exists()
 
 
@@ -36,5 +38,6 @@ class TestSquashUnpacker(TestUnpackerBase):
         self.check_unpacker_selection('filesystem/squashfs', 'SquashFS')
 
     def test_extraction_sqfs(self):
-        self.check_unpacking_of_standard_unpack_set(TEST_DATA_DIR / 'sqfs.img',
-                                                    additional_prefix_folder='fact_extracted')
+        self.check_unpacking_of_standard_unpack_set(
+            TEST_DATA_DIR / 'sqfs.img', additional_prefix_folder='fact_extracted'
+        )


### PR DESCRIPTION
Fixed a bug in the squashfs unpacker: the new version of sasquatch did not unpack all files of some lzma compressed file systems in some cases.