### PR TITLE
Don't add "fact_extracted" prefix

### DIFF
--- a/fact_extractor/plugins/unpacking/squashFS/code/squash_fs.py
+++ b/fact_extractor/plugins/unpacking/squashFS/code/squash_fs.py
@@ -30,7 +30,10 @@ def unpack_function(file_path, tmp_dir):
     '''
     unpack_result = {}
     for unpacker, parameter in SQUASH_UNPACKER:
-        output = execute_shell_command(f'fakeroot {unpacker} {parameter} -d {tmp_dir}/fact_extracted {file_path}')
+        # We need to force here since "-dest" does not allow existing directories
+        output = execute_shell_command(
+            f"fakeroot {unpacker} {parameter} -dest {tmp_dir} -force {file_path}",
+        )
         if _unpack_success(tmp_dir):
             unpack_result['unpacking_tool'] = unpacker.name
             unpack_result['output'] = output

--- a/fact_extractor/plugins/unpacking/squashFS/test/test_plugin_squashfs.py
+++ b/fact_extractor/plugins/unpacking/squashFS/test/test_plugin_squashfs.py
@@ -39,5 +39,5 @@ class TestSquashUnpacker(TestUnpackerBase):
 
     def test_extraction_sqfs(self):
         self.check_unpacking_of_standard_unpack_set(
-            TEST_DATA_DIR / 'sqfs.img', additional_prefix_folder='fact_extracted'
+            TEST_DATA_DIR / 'sqfs.img',
         )


### PR DESCRIPTION
To me it does not make sense why the prefix as added at all. Also how would you distinguish between a tar that contains only one directory "fact_extracted"?