### PR TITLE
Pin pip dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ fact_extractor/install/pre_install.sh
 fact_extractor/install.py
 ```
 
-:warning: **We no longer support Ubuntu 16.04 and Python <3.7** 
+:warning: **We no longer support Ubuntu 18.04 and Python <3.8** 
 (It may still work with a bit of tinkering, though)
 
 :warning: For the `generic_fs` unpacker plugin to work with all file system types, you may need to install extra kernel modules

--- a/fact_extractor/helperFunctions/install.py
+++ b/fact_extractor/helperFunctions/install.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import configparser
 import logging
 import os
@@ -104,13 +106,22 @@ def pip_install_packages(*packages):
     for packet in packages:
         try:
             run_shell_command_raise_on_return_code(
-                f'{pip_command} install --upgrade {packet}', f'Error in installation of python package {packet}', True
+                f'{pip_command} install --upgrade "{packet}"',
+                f'Error in installation of python package {packet}',
+                True
             )
         except InstallationError as installation_error:
             if 'is a distutils installed project' in str(installation_error):
                 logging.warning(f'Could not update python packet {packet}. Was not installed using pip originally')
             else:
                 raise installation_error
+
+
+def load_requirements_file(path: Path) -> list[str]:
+    return [
+        line for line in path.read_text().splitlines()
+        if line and not line.startswith('#')
+    ]
 
 
 def check_if_command_in_path(command):

--- a/fact_extractor/install/common.py
+++ b/fact_extractor/install/common.py
@@ -4,47 +4,37 @@ from contextlib import suppress
 from pathlib import Path
 
 from helperFunctions.config import load_config
-from helperFunctions.install import apt_install_packages, apt_update_sources, pip_install_packages
+from helperFunctions.install import (
+    apt_install_packages, apt_update_sources, pip_install_packages, load_requirements_file
+)
 
-
-DEPENDENCIES = {
+APT_DEPENDENCIES = {
     # Ubuntu
-    'bionic': {},
-    'focal': {},
-    'jammy': {},
+    'bionic': [],
+    'focal': [],
+    'jammy': [],
     # Debian
-    'buster': {},
-    'bullseye': {},
+    'buster': [],
+    'bullseye': [],
     # Packages common to all platforms
-    'common': {
-        'apt': [
-            # Non python dependencies
-            'build-essential',
-            'automake',
-            'autoconf',
-            'libtool',
-            # Python dependencies
-            'python3',
-            'python3-dev',
-            'python-wheel-common',
-        ],
-        'pip3': [
-            'flask',
-            'flask_restful',
-            'gunicorn',
-            'pytest',
-            'pytest-cov',
-            'testresources',
-        ],
-    },
+    'common': [
+        # Non python dependencies
+        'build-essential',
+        'automake',
+        'autoconf',
+        'libtool',
+        # Python dependencies
+        'python3',
+        'python3-dev',
+        'python-wheel-common',
+    ],
 }
+PIP_DEPENDENCY_FILE = Path(__file__).parent.parent.parent / 'requirements-common.txt'
 
 
-def install_dependencies(dependencies):
-    apt = dependencies.get('apt', [])
-    pip3 = dependencies.get('pip3', [])
-    apt_install_packages(*apt)
-    pip_install_packages(*pip3)
+def install_apt_dependencies(distribution: str):
+    apt_install_packages(*APT_DEPENDENCIES['common'])
+    apt_install_packages(*APT_DEPENDENCIES[distribution])
 
 
 def main(distribution):
@@ -52,8 +42,8 @@ def main(distribution):
     apt_update_sources()
 
     # install dependencies
-    install_dependencies(DEPENDENCIES['common'])
-    install_dependencies(DEPENDENCIES[distribution])
+    install_apt_dependencies(distribution)
+    pip_install_packages(*load_requirements_file(PIP_DEPENDENCY_FILE))
 
     # make bin dir
     with suppress(FileExistsError):

--- a/fact_extractor/install/unpacker.py
+++ b/fact_extractor/install/unpacker.py
@@ -16,6 +16,7 @@ from helperFunctions.install import (
     apt_remove_packages,
     install_github_project,
     pip_install_packages,
+    load_requirements_file,
 )
 
 BIN_DIR = Path(__file__).parent.parent / 'bin'
@@ -154,44 +155,6 @@ DEPENDENCIES = {
             # 7z
             'yasm',
         ],
-        'pip3': [
-            'pluginbase',
-            'git+https://github.com/armbues/python-entropy',  # To be checked. Original dependency was deleted.
-            'git+https://github.com/fkie-cad/common_helper_unpacking_classifier.git',
-            'git+https://github.com/fkie-cad/fact_helper_file.git',
-            'git+https://github.com/wummel/patool.git',
-            'archmage',
-            # jefferson + deps
-            'git+https://github.com/sviehb/jefferson.git',
-            'cstruct==2.1',
-            'python-lzo',
-            # binwalk
-            'git+https://github.com/ReFirmLabs/binwalk@v2.3.2',
-            'pyqtgraph',
-            'capstone',
-            'numpy',
-            'scipy',
-            'git+https://github.com/jrspruitt/ubi_reader@v0.6.3-master',  # pinned as broken currently
-            # dji / dlink_shrs
-            'pycryptodome',
-            # hp / raw
-            'git+https://github.com/fkie-cad/common_helper_extraction.git',
-            # intel_hex
-            'intelhex',
-            # linuxkernel
-            'lz4',
-            'git+https://github.com/marin-m/vmlinux-to-elf',
-            # mikrotik
-            'npkPy',
-            # sevenz
-            'git+https://github.com/fkie-cad/common_helper_passwords.git',
-            # srec
-            'bincopy',
-            # uboot
-            'extract-dtb',
-            # uefi
-            'git+https://github.com/theopolis/uefi-firmware-parser@v1.10',
-        ],
         'github': [
             ('threadexio/sasquatch', ['./build.sh']),
             (
@@ -204,14 +167,14 @@ DEPENDENCIES = {
         ],
     },
 }
+PIP_DEPENDENCY_FILE = Path(__file__).parent.parent.parent / 'requirements-unpackers.txt'
 
 
 def install_dependencies(dependencies):
     apt = dependencies.get('apt', [])
-    pip3 = dependencies.get('pip3', [])
     github = dependencies.get('github', [])
     apt_install_packages(*apt)
-    pip_install_packages(*pip3)
+    pip_install_packages(*load_requirements_file(PIP_DEPENDENCY_FILE))
     for repo in github:
         install_github_project(*repo)
 

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,0 +1,6 @@
+flask~=3.0.3
+flask-restful~=0.3.10
+gunicorn~=21.2.0
+pytest<8.1.1
+pytest-cov~=5.0.0
+testresources~=2.0.1

--- a/requirements-unpackers.txt
+++ b/requirements-unpackers.txt
@@ -1,0 +1,38 @@
+# FixMe: deprecated
+pluginbase~=1.0.1
+git+https://github.com/fkie-cad/common_helper_unpacking_classifier.git
+git+https://github.com/fkie-cad/fact_helper_file.git
+patool~=2.2.0
+# jffs2: jefferson + deps
+git+https://github.com/sviehb/jefferson.git@v0.4.1
+cstruct==2.1
+python-lzo==1.14
+# generic_carver: binwalk
+# ToDo: pin to fork (?)
+git+https://github.com/ReFirmLabs/binwalk@v2.3.2
+pyqtgraph~=0.13.4
+capstone~=5.0.1
+numpy~=1.26.4
+scipy~=1.13.0
+# ubi
+ubi-reader~=0.8.9
+# dji / dlink_shrs
+pycryptodome~=3.20.0
+# hp / raw
+git+https://github.com/fkie-cad/common_helper_extraction.git
+# intel_hex
+intelhex~=2.3.0
+# linuxkernel
+lz4~=4.3.3
+# FixMe: this has also a dependency to a package called python-lzo (name conflict with python-lzo from jefferson)
+git+https://github.com/marin-m/vmlinux-to-elf
+# mikrotik
+npkPy~=2021.10.22.15.58
+# sevenz
+git+https://github.com/fkie-cad/common_helper_passwords.git
+# srec
+bincopy~=20.0.0
+# uboot
+extract-dtb~=1.2.3
+# uefi
+uefi-firmware~=1.11


### PR DESCRIPTION
- move all pip dependencies to requirements files so that GitHub's "dependabot" is able to track them for vulnerabilities
- pin all package versions (except for some of the packages that are directly installed from a repository)
  - this does not fix the name conflict between the `python-lzo` dependencies of jefferson and vmlinux-to-elf but I added a FixMe comment
- update versions in the readme.md