### PR TITLE
Modify entropy calculation to use mmap instead of read_bytes() to reduce memory usage for large files

### DIFF
--- a/fact_extractor/helperFunctions/statistics.py
+++ b/fact_extractor/helperFunctions/statistics.py
@@ -1,5 +1,6 @@
 from configparser import ConfigParser
 from contextlib import suppress
+from mmap import mmap
 from pathlib import Path
 from typing import Dict, List
 
@@ -23,7 +24,7 @@ def add_unpack_statistics(extraction_dir: Path, meta_data: Dict):
     meta_data['number_of_unpacked_directories'] = unpacked_directories
 
 
-def get_unpack_status(file_path: str, binary: bytes, extracted_files: List[Path], meta_data: Dict, config: ConfigParser):
+def get_unpack_status(file_path: str, binary: bytes | mmap, extracted_files: List[Path], meta_data: Dict, config: ConfigParser):
     meta_data['summary'] = []
     meta_data['entropy'] = avg_entropy(binary)
 

--- a/fact_extractor/unpacker/unpack.py
+++ b/fact_extractor/unpacker/unpack.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import mmap
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -52,9 +53,10 @@ class Unpacker(UnpackBase):
 
             compute_stats = self.config.getboolean('ExpertSettings', 'statistics', fallback=True)
             if compute_stats:
-                binary = Path(file_path).read_bytes()
                 add_unpack_statistics(self._file_folder, meta_data)
-                get_unpack_status(file_path, binary, extracted_files, meta_data, self.config)
+                with open(file_path, 'rb') as f:
+                    with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+                        get_unpack_status(file_path, mm, extracted_files, meta_data, self.config)
 
             self.cleanup(tmp_dir)
 


### PR DESCRIPTION
This is primarily relevant when extracting very large (e.g. 32GB+) firmware images.

There are other uses of `read_bytes()` and `read()` in the code that could be refactored to use `mmap`, but this is the only one that seemed strictly necessary. If you guys are interested in changing the other instances, I'm glad to look into it as part of this PR.