### PR TITLE
Support aarch64

### DIFF
--- a/fact_extractor/install/unpacker.py
+++ b/fact_extractor/install/unpacker.py
@@ -188,7 +188,7 @@ elif platform.machine() == 'aarch64':
         # zoo
         (
             'zoo_2.10-28_arm64.deb',
-            'http://ports.ubuntu.com/pool/universe/z/zoo/',
+            'http://ports.ubuntu.com/pool/universe/z/zoo',
             'e6600d4e878eddd18d1353664fae9bee015a8f9206aa62d2c9bfa070fe4cb7b3',
         ),
         # sasquatch

--- a/fact_extractor/install/unpacker.py
+++ b/fact_extractor/install/unpacker.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import os
+import platform
 from getpass import getuser
 from pathlib import Path
 from shlex import split
@@ -167,21 +168,36 @@ DEPENDENCIES = {
     },
 }
 PIP_DEPENDENCY_FILE = Path(__file__).parent.parent.parent / 'requirements-unpackers.txt'
-EXTERNAL_DEB_DEPS = [
-    # zoo
-    (
-        'zoo_2.10-28_amd64.deb',
-        'http://launchpadlibrarian.net/230277773',
-        '953f4f94095ef3813dfd30c8977475c834363aaabce15ab85ac5195e52fd816a',
-    ),
-    # sasquatch
-    (
-        'sasquatch_1.0_amd64.deb',
-        'https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4',
-        'bb211daf90069a43b7d5e76f136766a8542a5328015773e9b8be87541b307b60',
-    ),
-]
-
+if platform.machine() == 'x86_64':
+    EXTERNAL_DEB_DEPS = [
+        # zoo
+        (
+            'zoo_2.10-28_amd64.deb',
+            'http://launchpadlibrarian.net/230277773',
+            '953f4f94095ef3813dfd30c8977475c834363aaabce15ab85ac5195e52fd816a',
+        ),
+        # sasquatch
+        (
+            'sasquatch_1.0_amd64.deb',
+            'https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4',
+            'bb211daf90069a43b7d5e76f136766a8542a5328015773e9b8be87541b307b60',
+        ),
+    ]
+elif platform.machine() == 'aarch64':
+    EXTERNAL_DEB_DEPS = [
+        # zoo
+        (
+            'zoo_2.10-28_arm64.deb',
+            'http://ports.ubuntu.com/pool/universe/z/zoo/',
+            'e6600d4e878eddd18d1353664fae9bee015a8f9206aa62d2c9bfa070fe4cb7b3',
+        ),
+        # sasquatch
+        (
+            'sasquatch_1.0_arm64.deb',
+            'https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4',
+            'fb281906a25667414e8b6aff96b49ceb227519122a7844bbc8166f2b6a59554a',
+        ),
+    ]
 
 def install_dependencies(dependencies):
     apt = dependencies.get('apt', [])

--- a/fact_extractor/install/unpacker.py
+++ b/fact_extractor/install/unpacker.py
@@ -220,7 +220,8 @@ def main(distribution):
     install_dependencies(DEPENDENCIES[distribution])
 
     # installing freetz
-    _install_freetz()
+    if platform.machine() == 'x86_64':
+        _install_freetz()
 
     # install plug-in dependencies
     _install_plugins()

--- a/fact_extractor/plugins/unpacking/sevenz/install.sh
+++ b/fact_extractor/plugins/unpacking/sevenz/install.sh
@@ -22,7 +22,7 @@ cd p7zip*
 # gcc >= 11 has -Wnarrowing as default flag which leads to an error during compilation
 # g++ will try to use standard C++17 but the code is not compatible -> use C++14
 sed -i 's/CXXFLAGS=-c -I. \\/CXXFLAGS=-c -I. -Wno-narrowing -std=c++14 \\/g' makefile.glb  || echo "Warning: Could not apply makefile patch"
-cp makefile.linux_amd64_asm makefile.machine
+cp makefile.linux_any_cpu makefile.machine
 make -j"$(nproc)" all3
 sudo ./install.sh
 cd ..


### PR DESCRIPTION
I'm aiming to run FACT on aarch64.

Changes:
* change the 7zip makefile from `linux_amd64_asm` to `linux_any_cpu` to enable building for different architectures. As it stands, attempting to build on aarch64 results in g++ failing to understand `-m64` since that is an x86-only flag.
* dynamically choose between arm64 and amd64 sasquatch and zoo .debs
* disable freetz-ng for now on aarch64, since they apparently have x86-specific stuff going on (toolchain stuff)

Depends:
* https://github.com/fkie-cad/entropython/issues/2
* https://github.com/fkie-cad/docker-radare-web-gui/pull/2

With all these things in check, I was able to build the `fact_extractor` container on my rk3588 (aarch64)-based Ubuntu VM.

```
fkiecad/fact_extractor                  latest    e5a3bf597b68   19 seconds ago      2.44GB
```