### PR TITLE
workflows: enable aarch64 build and push

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -25,3 +25,4 @@ jobs:
           context: .
           push: true
           tags: fkiecad/fact_extractor:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
I'm probably the furthest thing from a Docker expert, but I _think_ this should create aarch64 images and push them up to dockerhub. Not sure exactly how I can test this one.