### PR TITLE
fix: reenabled CLI logging output

### DIFF
--- a/fact_extractor/helperFunctions/program_setup.py
+++ b/fact_extractor/helperFunctions/program_setup.py
@@ -23,7 +23,6 @@ def setup_argparser(name, description, command_line_options, version=__VERSION__
 
 
 def setup_logging(debug, log_file=None, log_level=None):
-    log_level = log_level if log_level else logging.WARNING
     log_format = logging.Formatter(
         fmt='[%(asctime)s][%(module)s][%(levelname)s]: %(message)s', datefmt='%Y-%m-%d %H:%M:%S'
     )
@@ -33,13 +32,12 @@ def setup_logging(debug, log_file=None, log_level=None):
     if log_file:
         create_dir_for_file(log_file)
         file_log = logging.FileHandler(log_file)
-        file_log.setLevel(log_level)
+        file_log.setLevel(log_level or logging.WARNING)
         file_log.setFormatter(log_format)
         logger.addHandler(file_log)
 
-    log_level = log_level if log_level else logging.INFO
     console_log = logging.StreamHandler()
-    console_log.setLevel(logging.DEBUG if debug else log_level)
+    console_log.setLevel(logging.DEBUG if debug else log_level or logging.INFO)
     console_log.setFormatter(log_format)
     logger.addHandler(console_log)
 
@@ -47,10 +45,10 @@ def setup_logging(debug, log_file=None, log_level=None):
 def check_ulimits():
     # Get number of openable files
     soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-    if soft < 1024:
+    if soft < 1024:  # noqa: PLR2004
         resource.setrlimit(resource.RLIMIT_NOFILE, (min(1024, hard), hard))
         logging.info(f'The number of openable files has been raised from {soft} to {min(1024, hard)}.')
-    elif soft == resource.RLIM_INFINITY or soft > 100000:
+    elif soft == resource.RLIM_INFINITY or soft > 100000:  # noqa: PLR2004
         logging.warning('Warning: A very high (or no) nofile limit will slow down fakeroot and cause other problems.')
 
 

--- a/fact_extractor/plugins/unpacking/generic_carver/code/generic_carver.py
+++ b/fact_extractor/plugins/unpacking/generic_carver/code/generic_carver.py
@@ -4,6 +4,7 @@ This plugin unpacks all files via carving
 
 from __future__ import annotations
 
+import logging
 import traceback
 from itertools import chain
 from pathlib import Path
@@ -28,6 +29,9 @@ MIN_FILE_ENTROPY = 0.01
 
 # deactivate internal debug logging of unblob finder because it can slow down chunks search significantly
 logger.debug = lambda *_, **__: None
+
+# global loglevel gets set to critical when importing Unblob -> reset it
+logging.getLogger().setLevel(logging.DEBUG)
 
 
 HANDLERS = (*BUILTIN_HANDLERS, *CUSTOM_HANDLERS)

--- a/fact_extractor/unpacker/unpackBase.py
+++ b/fact_extractor/unpacker/unpackBase.py
@@ -4,18 +4,16 @@ from __future__ import annotations
 import fnmatch
 import logging
 from os import getgid, getuid
+from pathlib import Path
 from subprocess import PIPE, Popen
 from time import time
-from typing import TYPE_CHECKING, Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple
 
 from common_helper_files import get_files_in_dir
 
 from helperFunctions import magic
 from helperFunctions.config import read_list_from_config
 from helperFunctions.plugin import import_plugins
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 class UnpackBase:
@@ -32,7 +30,7 @@ class UnpackBase:
     def _setup_plugins(self):
         self.unpacker_plugins = {}
         self.load_plugins()
-        logging.info(f'Plug-ins available: {self.source.list_plugins()}')
+        logging.debug(f'Plugins available: {self.source.list_plugins()}')
         self._set_whitelist()
 
     def load_plugins(self):
@@ -86,7 +84,7 @@ class UnpackBase:
         meta_data['plugin_used'] = name
         meta_data['plugin_version'] = version
 
-        logging.debug(f'Try to unpack {file_path} with {name} plugin...')
+        logging.info(f'Trying to unpack "{Path(file_path).name}" with plugin {name}')
 
         try:
             additional_meta = unpack_function(file_path, tmp_dir)


### PR DESCRIPTION
re-enabled CLI logging output after it was disabled when switching to Unblob as carver (because it was globally set to critical in a module of unblob)