### PR TITLE
fix: squashfs unpacker fixes

### DIFF
--- a/fact_extractor/plugins/unpacking/generic_fs/code/generic_fs.py
+++ b/fact_extractor/plugins/unpacking/generic_fs/code/generic_fs.py
@@ -23,7 +23,7 @@ MIME_PATTERNS = [
     'filesystem/xfs',
     'generic/fs',
 ]
-VERSION = '0.6.1'
+VERSION = '0.6.2'
 TYPES = {
     'filesystem/btrfs': 'btrfs',
     'filesystem/f2fs': 'f2fs',
@@ -31,6 +31,7 @@ TYPES = {
     'filesystem/minix': 'minix',
     'filesystem/reiserfs': 'reiserfs',
     'filesystem/romfs': 'romfs',
+    'filesystem/squashfs': 'squashfs',
     'filesystem/udf': 'udf',
     'filesystem/xfs': 'xfs',
 }

--- a/fact_extractor/plugins/unpacking/squashFS/code/squash_fs.py
+++ b/fact_extractor/plugins/unpacking/squashFS/code/squash_fs.py
@@ -17,13 +17,13 @@ UNSQUASHFS3_MULTI = Path(get_fact_bin_dir()) / 'unsquashfs3-multi'
 
 NAME = 'SquashFS'
 MIME_PATTERNS = ['filesystem/squashfs']
-VERSION = '0.11.0'
+VERSION = '0.11.1'
 SQUASH_UNPACKER = [
     (SASQUATCH, ''),
     (SASQUATCH_BE, ''),
     (UNSQUASHFS4_AVM_BE, '-scan'),
     (UNSQUASHFS4_AVM_LE, '-scan'),
-    (UNSQUASHFS3_MULTI, '-scan'),
+    (UNSQUASHFS3_MULTI, ''),
 ]
 
 


### PR DESCRIPTION
- squashfs v3 unpacker argument fix
  - removed -scan argument which does not appear to exist
- genericfs squashfs3 fix: fix for "unknown filesystem type 'squashfs3'"