### PR TITLE
Uboot carving fix

### DIFF
--- a/fact_extractor/plugins/unpacking/tpl/code/TPWRN702N.py
+++ b/fact_extractor/plugins/unpacking/tpl/code/TPWRN702N.py
@@ -1,4 +1,8 @@
+# noqa: N999
+from __future__ import annotations
+
 import binascii
+from pathlib import Path
 from struct import unpack
 
 from common_helper_files import write_binary_to_file
@@ -8,17 +12,18 @@ from unpacker.helper.carving import Carver
 NAME = 'TP-WR702N'
 MIME_PATTERNS = ['firmware/tp-wr702n']
 VERSION = '0.1.2'
+MIN_CARVING_SIZE = 10
 
 
-class InvalidImg0InformationException(Exception):
+class InvalidImg0InformationError(Exception):
     pass
 
 
-class Img0MissingException(Exception):
+class Img0MissingError(Exception):
     pass
 
 
-class NotLZMAException(Exception):
+class NotLZMAError(Exception):
     pass
 
 
@@ -38,7 +43,7 @@ def unpack_function(file_path, tmp_dir):
 
     remaining = tpwr702n.get_remaining_blocks()
     for offset, block in remaining.items():
-        if len(block) < 10:
+        if len(block) < MIN_CARVING_SIZE:
             continue
         write_binary_to_file(block, f'{tmp_dir}/{offset}_unknown.bin')
 
@@ -54,13 +59,12 @@ class TPWR702N:
     BOOTLOADER_OFFSET = 26820
     OS_OFFSET = 262420
 
-    def __init__(self, filename):
+    def __init__(self, filename: str | Path):
         self.img0 = None
         self.md5_checksum = None
-        self.firmware_filepath = filename
-        self.firmware = open(filename, 'rb')
-        self._read_container_information()
-        self.firmware.close()
+        self.firmware_filepath = Path(filename)
+        with self.firmware_filepath.open('rb') as file:
+            self._read_container_information(file)
 
         self.carver = Carver(self.firmware_filepath)
 
@@ -90,11 +94,10 @@ class TPWR702N:
         meta_data['uncarved_area'] = self.carver.carved.uncarved_areas
         return meta_data
 
-    def _read_container_information(self):
-        header = unpack('>4s16s', self.firmware.read(4 + self.MD5SIZE))
+    def _read_container_information(self, file):
+        header = unpack('>4s16s', file.read(4 + self.MD5SIZE))
         self.container_format = header[0]
         self.md5_checksum = header[1]
-
         self._read_img0()
 
     def _read_img0(self):
@@ -111,9 +114,9 @@ class TPWR702N:
 
     def _get_end_of_bootloader(self):
         if self.img0 is None:
-            raise Img0MissingException('Main IMG0 is missing')
+            raise Img0MissingError('Main IMG0 is missing')
         if self.img0.sub_header is None:
-            raise Img0MissingException('Sub IMG0 is missing')
+            raise Img0MissingError('Sub IMG0 is missing')
 
         return self.img0.sub_header.offset - 1
 
@@ -121,7 +124,7 @@ class TPWR702N:
     def _check_expected_lzma_property(data_block):
         lzma_first_byte = b'\x6e'
         if data_block[0] is not lzma_first_byte[0]:
-            raise NotLZMAException
+            raise NotLZMAError
 
     def get_os_and_fs(self):
         os_and_fs = self.carver.extract_data(self.OS_OFFSET)
@@ -149,7 +152,7 @@ class TPIMG0:  # pylint: disable=too-many-instance-attributes
     LANGUAGE_TP_LINK_CHINESE = b'\x00\x01'
     LANGUAGE_TP_LINK_ENGLISH = b'\x11\x01'
 
-    def __init__(self, filename, offset):
+    def __init__(self, filename: str | Path, offset: int):
         self.offset = offset
         self.header_size = 12
 
@@ -157,17 +160,22 @@ class TPIMG0:  # pylint: disable=too-many-instance-attributes
         self.language = None
         self.container_size = -1
 
-        self.firmware_filepath = filename
-        self.firmware = open(filename, 'rb')
-        self.firmware.seek(offset)
-        self._read_container_information()
-        self.sub_header = self._read_sub_header()
-        self.firmware.close()
+        self.firmware_filepath = Path(filename)
+        with self.firmware_filepath.open('rb') as file:
+            file.seek(offset)
+            self._read_container_information(file)
+            self.sub_header = self._read_sub_header(file)
 
         self.check_header()
 
     def __str__(self):
-        return f'IMG0\nSize: {self.container_size}\nDevice ID: {self.device_id}\nLanguage: {self.language}\nSubheader: {self.sub_header}'
+        return (
+            'IMG0\n'
+            f'Size: {self.container_size}\n'
+            f'Device ID: {self.device_id}\n'
+            f'Language: {self.language}\n'
+            f'Subheader: {self.sub_header}'
+        )
 
     def get_meta_dict(self):
         meta_data = {}
@@ -187,15 +195,15 @@ class TPIMG0:  # pylint: disable=too-many-instance-attributes
             return 'English'
         return 'Unknown'
 
-    def _read_container_information(self):
-        header = unpack('>4sI2s2s', self.firmware.read(self.header_size))
+    def _read_container_information(self, file):
+        header = unpack('>4sI2s2s', file.read(self.header_size))
         self.container_size = header[1]
         self.device_id = header[2]
         self.language = header[3]
 
-    def _read_sub_header(self):
-        self.firmware.seek(self.offset + self.header_size)
-        rest_of_the_file = self.firmware.read()
+    def _read_sub_header(self, file):
+        file.seek(self.offset + self.header_size)
+        rest_of_the_file = file.read()
         sub_header_offset = rest_of_the_file.find(b'\x49\x4d\x47\x30')
         if sub_header_offset < 0:
             return None
@@ -204,13 +212,13 @@ class TPIMG0:  # pylint: disable=too-many-instance-attributes
 
     def check_header(self):
         if self.container_size <= 0:
-            raise InvalidImg0InformationException(f'Size is {self.container_size}')
+            raise InvalidImg0InformationError(f'Size is {self.container_size}')
 
         if self.device_id is None:
-            raise InvalidImg0InformationException('Device Id is missing')
+            raise InvalidImg0InformationError('Device Id is missing')
 
         if self.language is None:
-            raise InvalidImg0InformationException('Language is missing')
+            raise InvalidImg0InformationError('Language is missing')
 
         return True
 

--- a/fact_extractor/plugins/unpacking/tpl/code/TPWRN702N.py
+++ b/fact_extractor/plugins/unpacking/tpl/code/TPWRN702N.py
@@ -7,7 +7,7 @@ from unpacker.helper.carving import Carver
 
 NAME = 'TP-WR702N'
 MIME_PATTERNS = ['firmware/tp-wr702n']
-VERSION = '0.1.1'
+VERSION = '0.1.2'
 
 
 class InvalidImg0InformationException(Exception):
@@ -37,8 +37,10 @@ def unpack_function(file_path, tmp_dir):
     write_binary_to_file(tpwr702n.get_fs(), f'{tmp_dir}/main.owfs')
 
     remaining = tpwr702n.get_remaining_blocks()
-    for offset in remaining:
-        write_binary_to_file(remaining[offset], f'{tmp_dir}/{offset}_unknown.bin')
+    for offset, block in remaining.items():
+        if len(block) < 10:
+            continue
+        write_binary_to_file(block, f'{tmp_dir}/{offset}_unknown.bin')
 
     return tpwr702n.get_meta_dict()
 
@@ -66,11 +68,11 @@ class TPWR702N:
         return f'MD5: {self.get_md5string()} \n Included Header:\n{self.img0!s}'
 
     def get_remaining_blocks(self):
-        non_carved_areas = self.carver.carved.non_carved_areas
+        non_carved_areas = self.carver.carved.uncarved_areas
 
         remaining = {}
         for area in non_carved_areas:
-            remaining[area[0]] = self.carver.extract_data(area[0], area[1])
+            remaining[area.start] = self.carver.extract_data(area.start, area.end)
         return remaining
 
     def get_container_header(self):
@@ -85,7 +87,7 @@ class TPWR702N:
         meta_data['os_offset'] = self.OS_OFFSET
         meta_data['md5'] = self.get_md5string()
         meta_data['img0'] = self.img0.get_meta_dict()
-        meta_data['uncarved_area'] = self.carver.carved.non_carved_areas
+        meta_data['uncarved_area'] = self.carver.carved.uncarved_areas
         return meta_data
 
     def _read_container_information(self):

--- a/fact_extractor/plugins/unpacking/uboot/code/uboot.py
+++ b/fact_extractor/plugins/unpacking/uboot/code/uboot.py
@@ -1,36 +1,37 @@
-import mmap
-import os
+from __future__ import annotations
+
 from pathlib import Path
 
 from common_helper_process import execute_shell_command
 
-from unpacker.helper.carving import Carver
 from plugins.unpacking.uboot.internal.uboot_container import uBootHeader
+from unpacker.helper.carving import Carver
 
 NAME = 'Uboot'
 MIME_PATTERNS = ['firmware/u-boot']
 VERSION = '0.2.1'
 DTB_MAGIC = b'\xd0\x0d\xfe\xed'
+MIN_CARVING_SIZE = 10
 
 
 def unpack_function(file_path, tmp_dir):
     unpacker = Uboot(file_path)
     meta = {}
 
-    uboot_path = f'{tmp_dir}/uboot.{uBootHeader.COMPRESSION[unpacker.ubootheader.compression_type]}'
-    with open(uboot_path, 'wb') as uboot:
+    uboot_path = Path(f'{tmp_dir}/uboot.{uBootHeader.COMPRESSION[unpacker.ubootheader.compression_type]}')
+    with uboot_path.open('wb') as uboot:
         uboot.write(unpacker.extract_uboot_image())
 
-    uboot_header_path = f'{tmp_dir}/uboot_header.bin'
-    with open(uboot_header_path, 'wb') as uboot:
+    uboot_header_path = Path(f'{tmp_dir}/uboot_header.bin')
+    with uboot_header_path.open('wb') as uboot:
         uboot.write(unpacker.extract_uboot_header())
 
     remaining = unpacker.get_remaining_blocks()
     for offset, block in remaining.items():
-        if len(block) < 10:
+        if len(block) < MIN_CARVING_SIZE:
             continue
-        unknown_path = f'{tmp_dir}/{offset}_unknown.bin'
-        with open(unknown_path, 'wb') as hdr:
+        unknown_path = Path(f'{tmp_dir}/{offset}_unknown.bin')
+        with unknown_path.open('wb') as hdr:
             hdr.write(block)
 
     # scan for device tree blobs
@@ -44,11 +45,10 @@ def unpack_function(file_path, tmp_dir):
 
 
 class Uboot:
-    def __init__(self, filename):
-        self.firmware_filepath = filename
+    def __init__(self, filename: str | Path):
+        self.firmware_filepath = Path(filename)
 
-        statinfo = os.stat(self.firmware_filepath)
-        self.firmware_size = statinfo.st_size
+        self.firmware_size = self.firmware_filepath.stat().st_size
 
         self.carver = Carver(self.firmware_filepath)
         self.ubootheader = self._set_uboot_header()
@@ -67,11 +67,9 @@ class Uboot:
         )
 
     def _set_uboot_header(self):
-        with open(self.firmware_filepath, 'r+b') as raw_file:
-            mm = mmap.mmap(raw_file.fileno(), 0)
-
+        with self.firmware_filepath.open('rb') as raw_file:
             ubootheader = uBootHeader()
-            ubootheader.create_from_binary(mm.read(uBootHeader.HEADER_LENGTH))
+            ubootheader.create_from_binary(raw_file.read(uBootHeader.HEADER_LENGTH))
         return ubootheader
 
     def extract_uboot_header(self):

--- a/fact_extractor/plugins/unpacking/uboot/code/uboot.py
+++ b/fact_extractor/plugins/unpacking/uboot/code/uboot.py
@@ -1,29 +1,19 @@
 import mmap
 import os
-import sys
 from pathlib import Path
 
 from common_helper_process import execute_shell_command
 
 from unpacker.helper.carving import Carver
-
-THIS_FILE = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.join(THIS_FILE, '..', 'internal'))
-
-from uboot_container import uBootHeader  # noqa: E402 pylint: disable=import-error,wrong-import-position
+from plugins.unpacking.uboot.internal.uboot_container import uBootHeader
 
 NAME = 'Uboot'
 MIME_PATTERNS = ['firmware/u-boot']
-VERSION = '0.2'
+VERSION = '0.2.1'
 DTB_MAGIC = b'\xd0\x0d\xfe\xed'
 
 
 def unpack_function(file_path, tmp_dir):
-    """
-    file_path specifies the input file.
-    tmp_dir should be used to store the extracted files.
-    """
-
     unpacker = Uboot(file_path)
     meta = {}
 
@@ -37,6 +27,8 @@ def unpack_function(file_path, tmp_dir):
 
     remaining = unpacker.get_remaining_blocks()
     for offset, block in remaining.items():
+        if len(block) < 10:
+            continue
         unknown_path = f'{tmp_dir}/{offset}_unknown.bin'
         with open(unknown_path, 'wb') as hdr:
             hdr.write(block)
@@ -62,11 +54,11 @@ class Uboot:
         self.ubootheader = self._set_uboot_header()
 
     def get_remaining_blocks(self):
-        non_carved_areas = self.carver.carved.non_carved_areas
+        non_carved_areas = self.carver.carved.uncarved_areas
 
         remaining = {}
         for area in non_carved_areas:
-            remaining[area[0]] = self.carver.extract_data(area[0], area[1])
+            remaining[area.start] = self.carver.extract_data(area.start, area.end)
         return remaining
 
     def extract_uboot_image(self):

--- a/fact_extractor/test/unit/unpacker/test_carved_area.py
+++ b/fact_extractor/test/unit/unpacker/test_carved_area.py
@@ -1,22 +1,25 @@
 import pytest
 
-from unpacker.helper.carving import CarvingArea, Area
+from unpacker.helper.carving import Area, CarvingArea
 
 
-@pytest.mark.parametrize('start, end, expected', [
-    # complete area
-    (0, 100, []),
-    (-1, 101, []),
-    (-1, 100, []),
-    (0, 101, []),
-    # borders
-    (0, 99, [Area(99, 100)]),
-    (1, 100, [Area(0, 1)]),
-    (-1, 99, [Area(99, 100)]),
-    (1, 101, [Area(0, 1)]),
-    # in between
-    (50, 60, [Area(0, 50), Area(60, 100)]),
-])
+@pytest.mark.parametrize(
+    ('start', 'end', 'expected'),
+    [
+        # complete area
+        (0, 100, []),
+        (-1, 101, []),
+        (-1, 100, []),
+        (0, 101, []),
+        # borders
+        (0, 99, [Area(99, 100)]),
+        (1, 100, [Area(0, 1)]),
+        (-1, 99, [Area(99, 100)]),
+        (1, 101, [Area(0, 1)]),
+        # in between
+        (50, 60, [Area(0, 50), Area(60, 100)]),
+    ],
+)
 def test_add_carved_area(start, end, expected):
     carved_area = CarvingArea(100)
     carved_area.add_carved_area(Area(start, end))

--- a/fact_extractor/test/unit/unpacker/test_carved_area.py
+++ b/fact_extractor/test/unit/unpacker/test_carved_area.py
@@ -1,62 +1,46 @@
-import gc
+import pytest
 
-from unpacker.helper.carving import CarvedArea
+from unpacker.helper.carving import CarvingArea, Area
 
 
-class TestCarvedArea:
-    def teardown_method(self):
-        gc.collect()
+@pytest.mark.parametrize('start, end, expected', [
+    # complete area
+    (0, 100, []),
+    (-1, 101, []),
+    (-1, 100, []),
+    (0, 101, []),
+    # borders
+    (0, 99, [Area(99, 100)]),
+    (1, 100, [Area(0, 1)]),
+    (-1, 99, [Area(99, 100)]),
+    (1, 101, [Area(0, 1)]),
+    # in between
+    (50, 60, [Area(0, 50), Area(60, 100)]),
+])
+def test_add_carved_area(start, end, expected):
+    carved_area = CarvingArea(100)
+    carved_area.add_carved_area(Area(start, end))
+    assert carved_area.uncarved_areas == expected
 
-    def test_carved_complete_area(self):
-        area_size = 100
-        carved_and_expected = [
-            {'carved': (0, area_size), 'expected': []},
-            {'carved': (-1, area_size + 1), 'expected': []},
-            {'carved': (-1, area_size), 'expected': []},
-            {'carved': (0, area_size + 1), 'expected': []},
-        ]
-        self.caring_test(area_size, carved_and_expected)
 
-    def test_carved_borders(self):
-        area_size = 100
-        carved_and_expected = [
-            {'carved': (0, area_size - 1), 'expected': [(100, 100)]},
-            {'carved': (1, area_size), 'expected': [(0, 0)]},
-            {'carved': (-1, area_size - 1), 'expected': [(100, 100)]},
-            {'carved': (1, area_size + 1), 'expected': [(0, 0)]},
-        ]
-        self.caring_test(area_size, carved_and_expected)
+def test_bug():
+    area_size = 8258048
+    carved_area = CarvingArea(area_size)
 
-    def test_carved_in_between(self):
-        area_size = 100
-        carved_and_expected = [{'carved': (50, 60), 'expected': [(0, 49), (61, 100)]}]
-        self.caring_test(area_size, carved_and_expected)
+    carved_area.add_carved_area(Area(0, 512))
 
-    def test_bug(self):
-        area_size = 8258048
-        carved_area = CarvedArea(area_size)
+    carved_area.add_carved_area(Area(15440, 15504))
+    carved_area.add_carved_area(Area(15504, 48257))
 
-        carved_area.carved((0, 512))
+    carved_area.add_carved_area(Area(131584, 132096))
+    carved_area.add_carved_area(Area(132096, 1066830))
 
-        carved_area.carved((15440, 15504))
-        carved_area.carved((15504, 48257))
+    carved_area.add_carved_area(Area(1180160, 8258048))
 
-        carved_area.carved((131584, 132096))
-        carved_area.carved((132096, 1066830))
+    expected = [Area(512, 15440), Area(48257, 131584), Area(1066830, 1180160)]
+    assert len(carved_area.uncarved_areas) == len(expected)
 
-        carved_area.carved((1180160, 8258048))
+    for area in expected:
+        assert area in carved_area.uncarved_areas
 
-        expected = [(513, 15439), (48258, 131583), (1066831, 1180159)]
-        assert len(carved_area.non_carved_areas) == len(expected)
-
-        for area in expected:
-            assert area in carved_area.non_carved_areas
-
-        assert str(carved_area) == '(513:15439) (48258:131583) (1066831:1180159) '
-
-    def caring_test(self, area_size, carved_and_expected):
-        for test_data in carved_and_expected:
-            carved_area = CarvedArea(area_size)
-            carved_area.carved(test_data['carved'])
-
-            assert test_data['expected'] == carved_area.non_carved_areas, test_data
+    assert str(carved_area) == '(512:15440) (48257:131584) (1066830:1180160)'

--- a/fact_extractor/unpacker/helper/carving.py
+++ b/fact_extractor/unpacker/helper/carving.py
@@ -70,6 +70,5 @@ class Carver:
             if end is not None:
                 self.carved.add_carved_area(Area(start, end))
                 return opened_file.read(end - start)
-            else:
-                self.carved.add_carved_area(Area(start, self.file_size))
-                return opened_file.read()
+            self.carved.add_carved_area(Area(start, self.file_size))
+            return opened_file.read()

--- a/fact_extractor/unpacker/helper/carving.py
+++ b/fact_extractor/unpacker/helper/carving.py
@@ -1,49 +1,75 @@
-import os
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
 
 
-class CarvedArea:
-    def __init__(self, size):
-        self.non_carved_areas = [(0, size)]
+class Area(NamedTuple):
+    # start offset is inclusive and end offset is exclusive!
+    start: int
+    end: int
 
-    def carved(self, carved_area):
-        areas = self.non_carved_areas
-        self.non_carved_areas = []
-        for area in areas:
-            if carved_area[0] > area[1] or area[0] > carved_area[1]:
-                self.non_carved_areas.append((area[0], area[1]))
-            elif area[0] >= carved_area[0] and area[1] <= carved_area[1]:
-                pass
-            elif area[0] < carved_area[0] and area[1] <= carved_area[1]:
-                self.non_carved_areas.append((area[0], carved_area[0] - 1))
-            elif area[0] >= carved_area[0] and area[1] > carved_area[1]:
-                self.non_carved_areas.append((carved_area[1] + 1, area[1]))
-            elif area[0] < carved_area[0] and area[1] > carved_area[1]:
-                self.non_carved_areas.append((area[0], carved_area[0] - 1))
-                self.non_carved_areas.append((carved_area[1] + 1, area[1]))
+    def __str__(self):
+        return f'({self.start}:{self.end})'
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class CarvingArea:
+    def __init__(self, size: int):
+        self.uncarved_areas: list[Area] = [Area(0, size)]
+
+    def add_carved_area(self, carved_area: Area) -> None:
+        areas = self.uncarved_areas
+        self.uncarved_areas = []
+        for uncarved_area in areas:
+            if uncarved_area.end <= carved_area.start or carved_area.end <= uncarved_area.start:
+                # uncarved area before _______XXXXXX_  or _XXXXXX_________
+                # carved area          _YYYY_________  or __________YYYYY_
+                # uncarved area after  _______XXXXXX_  or _XXXXXX_________
+                self.uncarved_areas.append(uncarved_area)
+            elif carved_area.start <= uncarved_area.start and uncarved_area.end <= carved_area.end:
+                # uncarved area before _____XXXXXXXX______
+                # carved area          ____YYYYYYYYYY_____
+                # uncarved area after  ___________________
+                continue
+            elif uncarved_area.start < carved_area.start and uncarved_area.end <= carved_area.end:
+                # uncarved area before _____XXXXXXXX______
+                # carved area          ________YYYYYYY____
+                # uncarved area after  _____XXX___________
+                self.uncarved_areas.append(Area(uncarved_area.start, carved_area.start))
+            elif carved_area.start <= uncarved_area.start and carved_area.end < uncarved_area.end:
+                # uncarved area before _____XXXXXXXX______
+                # carved area          ___YYYYYY__________
+                # uncarved area after  _________XXXX______
+                self.uncarved_areas.append(Area(carved_area.end, uncarved_area.end))
+            elif uncarved_area.start < carved_area.start and carved_area.end < uncarved_area.end:
+                # uncarved area before ____XXXXXXXXXXX____
+                # carved area          _______YYYYY_______
+                # uncarved area after  ____XXX_____XXX____
+                self.uncarved_areas.append(Area(uncarved_area.start, carved_area.start))
+                self.uncarved_areas.append(Area(carved_area.end, uncarved_area.end))
             else:
                 raise Exception('Carving error')
 
     def __str__(self):
-        ret_val = ''
-        for area in self.non_carved_areas:
-            ret_val += f'({area[0]}:{area[1]}) '
-
-        return ret_val
+        return ' '.join(str(area) for area in self.uncarved_areas)
 
 
 class Carver:
-    def __init__(self, filepath):
-        self.filepath = filepath
-        self.file_size = os.stat(self.filepath).st_size
-        self.carved = CarvedArea(self.file_size)
+    def __init__(self, filepath: str | Path):
+        self.filepath = Path(filepath)
+        self.file_size = self.filepath.stat().st_size
+        self.carved = CarvingArea(self.file_size)
 
-    def extract_data(self, start, end=-1):
-        with open(self.filepath, 'rb') as opened_file:
+    def extract_data(self, start: int, end: int | None = None) -> bytes:
+        with self.filepath.open('rb') as opened_file:
             opened_file.seek(start)
 
-            if end >= 0:
-                self.carved.carved((start, end))
+            if end is not None:
+                self.carved.add_carved_area(Area(start, end))
                 return opened_file.read(end - start)
             else:
-                self.carved.carved((start, self.file_size))
+                self.carved.add_carved_area(Area(start, self.file_size))
                 return opened_file.read()


### PR DESCRIPTION
* fixed off-by-one errors in the `fact_extractor/unpacker/helper/carving.py` module
  * these errors resulted in filesystems not being unpacked because the first byte was missing
  * refactored the module to improve readability of the code
* also made small changes in the unpackers that use this helper class (uboot and tpl)
* ruff fixes