### PR TITLE
feat: make extracted filenames of generic_carver sortable

### DIFF
--- a/fact_extractor/plugins/unpacking/generic_carver/code/generic_carver.py
+++ b/fact_extractor/plugins/unpacking/generic_carver/code/generic_carver.py
@@ -5,6 +5,7 @@ This plugin unpacks all files via carving
 from __future__ import annotations
 
 import logging
+import re
 import traceback
 from itertools import chain
 from pathlib import Path
@@ -64,7 +65,19 @@ def unpack_function(file_path: str, tmp_dir: str) -> dict:
             report += f'\nFiltered chunks:\n{filter_report}'
     except Exception as error:
         report = f'Error {error} during unblob extraction:\n{traceback.format_exc()}'
+    _rename_extracted_files(Path(tmp_dir), path.stat().st_size)
     return {'output': report}
+
+
+def _rename_extracted_files(tmp_dir: Path, filesize: int):
+    """Default filenames are not sortable. This Function adds leading zeroes to the offsets to fix this."""
+    pad_width = len(str(filesize))
+    name_regex = re.compile(r'(\d+)-(\d+)\.(.+)')
+    for file in tmp_dir.iterdir():
+        if match := name_regex.match(file.name):
+            start, end, extension = match.groups()
+            filename = f'{int(start):0{pad_width}d}-{int(end):0{pad_width}d}.{extension}'
+            file.rename(tmp_dir / filename)
 
 
 def _find_chunks(file_path: Path, file: File) -> Iterable[Chunk]:

--- a/fact_extractor/plugins/unpacking/generic_carver/test/test_plugin_generic_carver.py
+++ b/fact_extractor/plugins/unpacking/generic_carver/test/test_plugin_generic_carver.py
@@ -1,11 +1,12 @@
 import re
 import zlib
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 
 from helperFunctions.file_system import get_test_data_dir
-from plugins.unpacking.generic_carver.code.generic_carver import unpack_function
+from plugins.unpacking.generic_carver.code.generic_carver import _rename_extracted_files, unpack_function
 from test.unit.unpacker.test_unpacker import TestUnpackerBase
 
 TEST_DATA_DIR = Path(__file__).parent / 'data'
@@ -45,7 +46,7 @@ class TestGenericCarver(TestUnpackerBase):
         files = set(files)
         assert len(files) == 4, 'file number incorrect'
         assert 'removed chunk 300-428' in meta_data['output']
-        for file in ('0-128.unknown', '128-300.zip', '428-562.sevenzip', '562-626.unknown'):
+        for file in ('000-128.unknown', '128-300.zip', '428-562.sevenzip', '562-626.unknown'):
             assert f'{self.tmp_dir.name}/{file}' in files
 
     @pytest.mark.parametrize('file_format', ['7z', 'gz', 'tar', 'xz', 'zip'])
@@ -62,3 +63,33 @@ class TestGenericCarver(TestUnpackerBase):
         meta = unpack_function(str(in_file), self.tmp_dir.name)
         carved_size = int(re.search(r'size: (\d+)', meta['output']).group(1))
         assert carved_size == expected_size
+
+
+def test_rename_extracted_files():
+    input_files = [
+        '0-576.unknown',
+        '1651790-2814674.xz',
+        '221934-619666.xz',
+        '2814674-3718110.unknown',
+        '3718110-7578970.xz',
+        '576-80860.xz',
+        '619666-1651790.unknown',
+        '80860-221934.unknown',
+    ]
+    with TemporaryDirectory() as tmp_dir:
+        path = Path(tmp_dir)
+        for f in input_files:
+            (path / f).touch()
+        _rename_extracted_files(path, 7578970)
+        renamed_files = sorted(f.name for f in path.iterdir())
+
+    assert renamed_files == [
+        '0000000-0000576.unknown',
+        '0000576-0080860.xz',
+        '0080860-0221934.unknown',
+        '0221934-0619666.xz',
+        '0619666-1651790.unknown',
+        '1651790-2814674.xz',
+        '2814674-3718110.unknown',
+        '3718110-7578970.xz',
+    ]


### PR DESCRIPTION
* names of carved files by unblob are not sortable
* this PR adds leading zeroes to fix this