### PR TITLE
fix: fixed jffs2 output parsing for new jefferson version

### DIFF
--- a/fact_extractor/plugins/unpacking/jffs2/code/jffs2.py
+++ b/fact_extractor/plugins/unpacking/jffs2/code/jffs2.py
@@ -9,8 +9,10 @@ from common_helper_process import execute_shell_command
 
 NAME = 'JFFS2'
 MIME_PATTERNS = ['filesystem/jffs2', 'filesystem/jffs2-big']
-VERSION = '0.7.0'
-ENTRY_REGEX = re.compile(r'(0x[0-9A-F]{8}): Jffs2_raw_(?:dirent|inode)\(magic=\d+, nodetype=\d+, totlen=(\d+)')
+VERSION = '0.7.1'
+ENTRY_REGEX = re.compile(
+    r'(0x[0-9A-Fa-f]{8}): <?Jffs2_raw_(?:dirent|inode) magic=0x[0-9a-f]+ nodetype=0x[0-9a-f]+ totlen=(0x[0-9a-f]+)'
+)
 
 
 def unpack_function(file_path, tmp_dir):
@@ -20,7 +22,7 @@ def unpack_function(file_path, tmp_dir):
     entries = ENTRY_REGEX.findall(output)
     if entries:
         last_offset, length = entries[-1]
-        fs_end = int(last_offset, 16) + int(length)
+        fs_end = int(last_offset, 16) + int(length, 0)
         return {'output': output, 'size': fs_end}
 
     return {'output': output}

--- a/fact_extractor/plugins/unpacking/jffs2/test/test_plugin_jffs2.py
+++ b/fact_extractor/plugins/unpacking/jffs2/test/test_plugin_jffs2.py
@@ -26,3 +26,10 @@ class TestJFFS2Unpacker(TestUnpackerBase):
         unpacked_files = {f.name: f for f in Path(self.tmp_dir.name).iterdir()}
         assert 'trailing.bin' in unpacked_files
         assert unpacked_files['trailing.bin'].read_bytes().startswith(b'foobar')
+
+    def test_jefferson_output_is_parsed(self):
+        _, meta_data = self.unpacker.base.extract_files_from_file(
+            str(TEST_DATA_DIR / 'jffs2_b2_trailing_data.img'), self.tmp_dir.name
+        )
+        assert 'size' in meta_data
+        assert meta_data['size'] == 612

--- a/requirements-unpackers.txt
+++ b/requirements-unpackers.txt
@@ -4,7 +4,7 @@ git+https://github.com/fkie-cad/common_helper_unpacking_classifier.git
 python-magic
 patool~=3.1.3
 # jffs2: jefferson + deps
-git+https://github.com/sviehb/jefferson.git@v0.4.1
+jefferson==0.4.7
 cstruct==2.1
 python-lzo==1.14
 # ubi


### PR DESCRIPTION
* fixes a bug where the changes to the output of jefferson in a new version makes the trailing data detection fail